### PR TITLE
Move default case to be int in __get_node_ids_to_sample

### DIFF
--- a/hyperbench/data/dataset.py
+++ b/hyperbench/data/dataset.py
@@ -268,9 +268,6 @@ class Dataset(TorchDataset):
         return unique_keys
 
     def __get_node_ids_to_sample(self, id: int | List[int]) -> List[int]:
-        if isinstance(id, int):
-            return [id]
-
         if isinstance(id, list):
             if len(id) < 1:
                 raise ValueError("Index list cannot be empty.")
@@ -279,6 +276,8 @@ class Dataset(TorchDataset):
                     "Index list length cannot exceed number of nodes in the hypergraph."
                 )
             return list(set(id))
+
+        return [id]
 
     def __validate_node_ids(self, node_ids: List[int]) -> None:
         for id in node_ids:


### PR DESCRIPTION
Simple refactor to `__get_node_ids_to_sample` by making int the default case so that tests cover it.