### PR TITLE
Set Lightning log level to ERROR

### DIFF
--- a/hyperbench/train/__init__.py
+++ b/hyperbench/train/__init__.py
@@ -1,3 +1,8 @@
+import logging
+
+logging.getLogger("lightning.pytorch").setLevel(logging.ERROR)
+
+
 from .negative_sampler import NegativeSampler, RandomNegativeSampler
 from .negative_sampling_scheduler import NegativeSamplingSchedule, NegativeSamplingScheduler
 from .trainer import MultiModelTrainer


### PR DESCRIPTION
I want to disable logs such as:

```text
💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.
GPU available: True (mps), used: True
TPU available: False, using: 0 TPU cores
```