### PR TITLE
Keep selfloops in LaplacianPositionalEncodingEnricher

### DIFF
--- a/hyperbench/tests/types/graph_test.py
+++ b/hyperbench/tests/types/graph_test.py
@@ -480,6 +480,23 @@ def test_edge_index_num_edges(edge_index_tensor, expected_num_edges):
 
 
 @pytest.mark.parametrize(
+    "edge_index_tensor, expected_max_node_id",
+    [
+        pytest.param(torch.tensor([[0], [1]]), 1, id="single_edge"),
+        pytest.param(torch.tensor([[0, 1, 2], [1, 2, 3]]), 3, id="multiple_edges"),
+        pytest.param(torch.tensor([[], []]), -1, id="empty_edge_index"),
+        pytest.param(torch.tensor([[0, 5], [3, 7]]), 7, id="non_consecutive_indices"),
+        pytest.param(torch.tensor([[0, 1, 1], [0, 1, 2]]), 2, id="with_selfloops"),
+        pytest.param(torch.tensor([[10, 20], [5, 15]]), 20, id="large_sparse_ids"),
+    ],
+)
+def test_edge_index_max_node_id(edge_index_tensor, expected_max_node_id):
+    edge_index = EdgeIndex(edge_index_tensor)
+
+    assert edge_index.max_node_id == expected_max_node_id
+
+
+@pytest.mark.parametrize(
     "edge_index_tensor, expected_num_nodes",
     [
         pytest.param(torch.tensor([[0], [1]]), 2, id="single_edge"),

--- a/hyperbench/tests/types/hypergraph_test.py
+++ b/hyperbench/tests/types/hypergraph_test.py
@@ -422,17 +422,17 @@ def test_hyperedge_index_nodes_in(hyperedge_index_tensor, hyperedge_id, expected
     [
         pytest.param(
             torch.tensor([[0, 1, 2], [0, 0, 0]]),
-            6,  # Clique of 3 nodes: 3 undirected edges = 6 directed
+            9,  # Clique of 3 nodes: 6 directed cross-edges + 3 self-loops
             id="single_hyperedge_3_nodes",
         ),
         pytest.param(
             torch.tensor([[0, 1], [0, 0]]),
-            2,  # Clique of 2 nodes: 1 undirected edge = 2 directed
+            4,  # Clique of 2 nodes: 2 directed cross-edges + 2 self-loops
             id="single_hyperedge_2_nodes",
         ),
         pytest.param(
             torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]]),
-            4,  # Two disjoint hyperedges of 2 nodes each: 2 undirected edges = 4 directed
+            8,  # Two disjoint hyperedges of 2 nodes each: 4 directed cross-edges + 4 self-loops
             id="two_disjoint_hyperedges",
         ),
     ],
@@ -442,27 +442,6 @@ def test_clique_expansion_edge_count(hyperedge_index_tensor, expected_num_edges)
 
     assert result.shape[0] == 2
     assert result.shape[1] == expected_num_edges
-
-
-def test_clique_expansion_removes_selfloops():
-    hyperedge_index = torch.tensor([[0, 1, 2], [0, 0, 0]])
-    result = HyperedgeIndex(hyperedge_index).reduce_to_edge_index_on_clique_expansion(
-        remove_selfloops=True
-    )
-
-    # No self-loops should be present (H @ H^T has zero diagonal)
-    assert torch.any(result[0] == result[1]).sum().item() == 0
-
-
-def test_clique_expansion_keeps_selfloops_when_disabled():
-    hyperedge_index = torch.tensor([[0, 1, 2], [0, 0, 0]])
-    result = HyperedgeIndex(hyperedge_index).reduce_to_edge_index_on_clique_expansion(
-        remove_selfloops=False
-    )
-
-    # Self-loops should be present (H @ H^T has non-zero diagonal)
-    selfloops = (result[0] == result[1]).sum().item()
-    assert selfloops > 0
 
 
 def test_clique_expansion_overlapping_hyperedges():

--- a/hyperbench/types/graph.py
+++ b/hyperbench/types/graph.py
@@ -117,6 +117,13 @@ class EdgeIndex:
         return self.__edge_index
 
     @property
+    def max_node_id(self) -> int:
+        """Return the maximum node ID in the edge index."""
+        if self.__edge_index.size(1) < 1:
+            return -1
+        return int(self.__edge_index.max())
+
+    @property
     def num_edges(self) -> int:
         """Return the number of edges in the graph."""
         if self.__edge_index.size(1) < 1:

--- a/hyperbench/types/hypergraph.py
+++ b/hyperbench/types/hypergraph.py
@@ -435,10 +435,7 @@ class HyperedgeIndex:
         """
         return max(self.num_nodes, num_nodes)
 
-    def reduce_to_edge_index_on_clique_expansion(
-        self,
-        remove_selfloops: bool = True,
-    ) -> Tensor:
+    def reduce_to_edge_index_on_clique_expansion(self) -> Tensor:
         """
         Construct a graph from a hypergraph via clique expansion using ``H @ H^T``, where ``H`` is the incidence matrix of the hypergraph.
         In clique expansion, each hyperedge is replaced by a clique connecting all its member nodes.
@@ -446,9 +443,6 @@ class HyperedgeIndex:
         For each hyperedge, all pairs of member nodes become edges in the resulting graph.
         This is computed efficiently using the incidence matrix: ``A = H @ H^T``, where ``H`` is
         the sparse incidence matrix of shape ``[num_nodes, num_hyperedges]`` and ``A`` is the adjacency matrix of the clique-expanded graph.
-
-        Args:
-            remove_selfloops: Whether to remove self-loops from the diagonal of ``H @ H^T``. Defaults to ``True``.
 
         Returns:
             The edge index of the clique-expanded graph. Size ``(2, |E'|)``.
@@ -486,10 +480,7 @@ class HyperedgeIndex:
         adj_matrix = torch.sparse.mm(incidence_matrix, incidence_matrix.t()).coalesce()
 
         # Extract edge_index, make undirected, and deduplicate
-        edge_index = EdgeIndex(adj_matrix.indices())
-        if remove_selfloops:
-            edge_index.remove_selfloops()
-        return edge_index.to_undirected().item
+        return EdgeIndex(adj_matrix.indices()).to_undirected().item
 
     def reduce_to_edge_index_on_random_direction(
         self,


### PR DESCRIPTION
### All Submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

The `LaplacianPositionalEncodingEnricher` removed selfloops when calling `reduce_to_edge_index_on_clique_expansion` causing issues as this was changing the underlying hypergraph. This is something that should not happen when enriching node features. As a user, I wouldn't expect the hypergraph to change during this process.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make lint`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
- [x] Have you added an explanation of what your changes are and why you'd like us to include them?
