### PR TITLE
Add methods to remove hyperedges by cardinality

### DIFF
--- a/examples/hypergcn.py
+++ b/examples/hypergcn.py
@@ -15,13 +15,14 @@ if __name__ == "__main__":
     metrics = MetricCollection(
         {
             "auc": BinaryAUROC(),
-            "ap": BinaryAveragePrecision(),
+            "avg_precision": BinaryAveragePrecision(),
         }
     )
 
     print("Loading and preparing dataset...")
 
     dataset = AlgebraDataset(sampling_strategy=sampling_strategy, prepare=True)
+    dataset.remove_hyperedges_with_fewer_than_k_nodes(k=2)
     dataset.enrich_node_features(
         enricher=LaplacianPositionalEncodingEnricher(num_features=32),
         enrichment_mode="replace",
@@ -57,7 +58,7 @@ if __name__ == "__main__":
         neg_hdata = negative_sampler.sample(ds.hdata)
         combined_hdata = HData.cat_same_node_space([ds.hdata, neg_hdata])
         shuffled_hdata = combined_hdata.shuffle(seed=42)
-        ds_with_negatives = AlgebraDataset.from_hdata(shuffled_hdata, sampling_strategy)
+        ds_with_negatives = ds.update_from_hdata(shuffled_hdata)
 
         if name == "Train":
             train_dataset = ds_with_negatives
@@ -128,7 +129,7 @@ if __name__ == "__main__":
 
     with MultiModelTrainer(
         model_configs=configs,
-        max_epochs=10,
+        max_epochs=200,
         accelerator="mps",
         log_every_n_steps=1,
         callbacks=[early_stopping],

--- a/examples/mlp_common_neighbors.py
+++ b/examples/mlp_common_neighbors.py
@@ -15,6 +15,7 @@ if __name__ == "__main__":
     metrics = MetricCollection(
         {
             "auc": BinaryAUROC(),
+            "avg_precision": BinaryAveragePrecision(),
         }
     )
 
@@ -56,7 +57,7 @@ if __name__ == "__main__":
         neg_hdata = negative_sampler.sample(ds.hdata)
         combined_hdata = HData.cat_same_node_space([ds.hdata, neg_hdata])
         shuffled_hdata = combined_hdata.shuffle(seed=42)
-        ds_with_negatives = AlgebraDataset.from_hdata(shuffled_hdata, sampling_strategy)
+        ds_with_negatives = ds.update_from_hdata(shuffled_hdata)
 
         if name == "Train":
             train_dataset = ds_with_negatives
@@ -79,14 +80,14 @@ if __name__ == "__main__":
     )
     val_loader = DataLoader(
         val_dataset,
-        batch_size=val_dataset.stats()["num_hyperedges"],
+        sample_full_hypergraph=True,
         shuffle=False,
         num_workers=num_workers,
         persistent_workers=True,
     )
     test_loader = DataLoader(
         test_dataset,
-        batch_size=test_dataset.stats()["num_hyperedges"],
+        sample_full_hypergraph=True,
         shuffle=False,
         num_workers=num_workers,
         persistent_workers=True,

--- a/hyperbench/data/dataset.py
+++ b/hyperbench/data/dataset.py
@@ -287,7 +287,28 @@ class Dataset(TorchDataset):
                 ``concatenate`` appends new features as additional columns.
                 ``replace`` substitutes ``hdata.x`` entirely.
         """
-        self.hdata.enrich_node_features(enricher, enrichment_mode)
+        self.hdata = self.hdata.enrich_node_features(enricher, enrichment_mode)
+
+    def update_from_hdata(self, hdata: HData) -> "Dataset":
+        """
+        Create a :class:`Dataset` instance from an :class:`HData` object.
+
+        Args:
+            hdata: :class:`HData` object containing the hypergraph data.
+
+        Returns:
+            The :class:`Dataset` instance with the provided :class:`HData`.
+        """
+        return self.__class__(hdata=hdata, sampling_strategy=self.sampling_strategy, prepare=False)
+
+    def remove_hyperedges_with_fewer_than_k_nodes(self, k: int) -> None:
+        """
+        Remove hyperedges that have fewer than k incident nodes.
+
+        Args:
+            k: The minimum number of nodes a hyperedge must have to be retained.
+        """
+        self.hdata = self.hdata.remove_hyperedges_with_fewer_than_k_nodes(k)
 
     def split(
         self,

--- a/hyperbench/data/loader.py
+++ b/hyperbench/data/loader.py
@@ -79,16 +79,16 @@ class DataLoader(TorchDataLoader):
         collated_x = self.__cached_dataset_hdata.x[hyperedge_index_wrapper.node_ids]
         collated_y = self.__cached_dataset_hdata.y[hyperedge_ids]
 
-        collated_hyeredge_attr = None
+        collated_hyperedge_attr = None
         if self.__cached_dataset_hdata.hyperedge_attr is not None:
-            collated_hyeredge_attr = self.__cached_dataset_hdata.hyperedge_attr[hyperedge_ids]
+            collated_hyperedge_attr = self.__cached_dataset_hdata.hyperedge_attr[hyperedge_ids]
 
         collated_hyperedge_index = hyperedge_index_wrapper.to_0based().item
 
         collated_hdata = HData(
             x=collated_x,
             hyperedge_index=collated_hyperedge_index,
-            hyperedge_attr=collated_hyeredge_attr,
+            hyperedge_attr=collated_hyperedge_attr,
             num_nodes=hyperedge_index_wrapper.num_nodes,
             num_hyperedges=hyperedge_index_wrapper.num_hyperedges,
             y=collated_y,

--- a/hyperbench/tests/data/dataset_test.py
+++ b/hyperbench/tests/data/dataset_test.py
@@ -938,6 +938,57 @@ def test_enrich_node_features_concatenate(mock_hdata):
     assert dataset.hdata.x.shape == (3, 5)  # 1 original + 4 enriched
 
 
+@pytest.mark.parametrize(
+    "hyperedge_index, k, expected_hyperedge_index",
+    [
+        pytest.param(
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            4,
+            torch.zeros((2, 0), dtype=torch.long),
+            id="single_hyperedge_below_k_removed",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            3,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="single_hyperedge_at_exact_k_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 0, 1, 1]]),
+            3,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="two_hyperedges_first_kept_second_removed",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 0, 1, 1, 1]]),
+            id="two_hyperedges_both_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 1, 1, 2, 2]]),
+            3,
+            torch.zeros((2, 0), dtype=torch.long),
+            id="three_hyperedges_all_removed",
+        ),
+    ],
+)
+def test_remove_hyperedges_with_fewer_than_k_nodes(hyperedge_index, k, expected_hyperedge_index):
+    num_nodes = hyperedge_index[0].max().item() + 1 if hyperedge_index.shape[1] > 0 else 0
+    x = torch.ones((num_nodes, 1), dtype=torch.float)
+    hdata = HData(x=x, hyperedge_index=hyperedge_index)
+    dataset = Dataset.from_hdata(hdata)
+
+    dataset.remove_hyperedges_with_fewer_than_k_nodes(k)
+
+    expected_num_nodes = expected_hyperedge_index[0].unique().shape[0]
+    expected_num_hyperedges = expected_hyperedge_index[1].unique().shape[0]
+
+    assert torch.equal(dataset.hdata.hyperedge_index, expected_hyperedge_index)
+    assert dataset.hdata.x.shape[0] == expected_num_nodes
+    assert dataset.hdata.y.shape[0] == expected_num_hyperedges
+
+
 def test_split_with_equal_ratios(mock_four_node_hypergraph):
     with patch.object(HIFConverter, "load_from_hif", return_value=mock_four_node_hypergraph):
         dataset = AlgebraDataset()
@@ -1124,6 +1175,60 @@ def test_from_hdata_with_explicit_strategy(mock_hdata):
 
     assert dataset.sampling_strategy == SamplingStrategy.NODE
     assert len(dataset) == 3  # mock_hdata has 3 nodes
+
+
+def test_update_from_hdata_returns_new_dataset(mock_hdata):
+    dataset = Dataset(hdata=mock_hdata, prepare=False)
+    new_x = torch.ones((2, 1), dtype=torch.float)
+    new_hyperedge_index = torch.tensor([[0, 1], [0, 0]], dtype=torch.long)
+    new_hdata = HData(x=new_x, hyperedge_index=new_hyperedge_index)
+
+    result = dataset.update_from_hdata(new_hdata)
+
+    assert result is not dataset
+    assert result.hdata is new_hdata
+    assert dataset.hdata is mock_hdata
+
+
+def test_update_from_hdata_stores_provided_hdata(mock_hdata):
+    dataset = Dataset(hdata=mock_hdata, prepare=False)
+    new_x = torch.ones((2, 1), dtype=torch.float)
+    new_hyperedge_index = torch.tensor([[0, 1], [0, 0]], dtype=torch.long)
+    new_hdata = HData(x=new_x, hyperedge_index=new_hyperedge_index)
+
+    result = dataset.update_from_hdata(new_hdata)
+
+    assert result.hdata is new_hdata
+
+
+@pytest.mark.parametrize(
+    "strategy, expected_len",
+    [
+        pytest.param(SamplingStrategy.NODE, 4, id="node_strategy"),
+        pytest.param(SamplingStrategy.HYPEREDGE, 3, id="hyperedge_strategy"),
+    ],
+)
+def test_update_from_hdata_inherits_sampling_strategy(mock_hdata, strategy, expected_len):
+    dataset = Dataset(hdata=mock_hdata, sampling_strategy=strategy, prepare=False)
+    new_x = torch.ones((4, 1), dtype=torch.float)
+    new_hyperedge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 2]], dtype=torch.long)
+    new_hdata = HData(x=new_x, hyperedge_index=new_hyperedge_index)
+
+    result = dataset.update_from_hdata(new_hdata)
+
+    assert result.sampling_strategy == strategy
+    assert len(result) == expected_len
+
+
+def test_update_from_hdata_preserves_subclass_type(mock_hdata):
+    dataset = AlgebraDataset(hdata=mock_hdata, prepare=False)
+    new_x = torch.ones((2, 1), dtype=torch.float)
+    new_hyperedge_index = torch.tensor([[0, 1], [0, 0]], dtype=torch.long)
+    new_hdata = HData(x=new_x, hyperedge_index=new_hyperedge_index)
+
+    result = dataset.update_from_hdata(new_hdata)
+
+    assert type(result) is AlgebraDataset
 
 
 @pytest.fixture

--- a/hyperbench/tests/types/hdata_test.py
+++ b/hyperbench/tests/types/hdata_test.py
@@ -499,10 +499,10 @@ def test_enrich_node_features_replace(mock_hdata):
     enriched_x = torch.randn(5, 3)
     enricher.enrich.return_value = enriched_x
 
-    mock_hdata.enrich_node_features(enricher)
+    result = mock_hdata.enrich_node_features(enricher)
 
     enricher.enrich.assert_called_once_with(mock_hdata.hyperedge_index)
-    assert torch.equal(mock_hdata.x, enriched_x)
+    assert torch.equal(result.x, enriched_x)
 
 
 def test_enrich_node_features_concatenate(mock_hdata):
@@ -512,12 +512,12 @@ def test_enrich_node_features_concatenate(mock_hdata):
     enriched_x = torch.randn(5, 3)
     enricher.enrich.return_value = enriched_x
 
-    mock_hdata.enrich_node_features(enricher, enrichment_mode="concatenate")
+    result = mock_hdata.enrich_node_features(enricher, enrichment_mode="concatenate")
 
     enricher.enrich.assert_called_once_with(mock_hdata.hyperedge_index)
     expected_x = torch.cat([original_x, enriched_x], dim=1)
-    assert torch.equal(mock_hdata.x, expected_x)
-    assert mock_hdata.x.shape == (5, 7)  # 4 original + 3 enriched
+    assert torch.equal(result.x, expected_x)
+    assert result.x.shape == (5, 7)  # 4 original + 3 enriched
 
 
 def test_get_device_if_all_consistent_returns_device_when_all_consistent():
@@ -701,6 +701,180 @@ def test_stats_returns_correct_statistics(mock_hdata_stats):
     stats = mock_hdata_stats.stats()
 
     assert stats == expected_stats
+
+
+@pytest.mark.parametrize(
+    "hyperedge_index, k, expected_hyperedge_index",
+    [
+        pytest.param(
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            4,
+            torch.zeros((2, 0), dtype=torch.long),
+            id="single_hyperedge_below_k_removed",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            3,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="single_hyperedge_at_exact_k_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 0, 1, 1]]),
+            3,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="two_hyperedges_first_kept_second_removed",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="two_hyperedges_second_kept_first_removed",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 0, 1, 1, 1]]),
+            id="two_hyperedges_both_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 1, 1, 2, 2]]),
+            3,
+            torch.zeros((2, 0), dtype=torch.long),
+            id="three_hyperedges_all_removed",
+        ),
+    ],
+)
+def test_remove_hyperedges_with_fewer_than_k_nodes(hyperedge_index, k, expected_hyperedge_index):
+    num_nodes = hyperedge_index[0].max().item() + 1
+    num_hyperedges = hyperedge_index[1].unique().shape[0]
+    x = torch.randn(num_nodes, 4)
+    y = torch.randn(num_hyperedges)
+    hyperedge_attr = torch.randn(num_hyperedges, 2)
+    hdata = HData(x=x, hyperedge_index=hyperedge_index, y=y, hyperedge_attr=hyperedge_attr)
+
+    result = hdata.remove_hyperedges_with_fewer_than_k_nodes(k)
+
+    expected_num_nodes = expected_hyperedge_index[0].unique().shape[0]
+    expected_num_hyperedges = expected_hyperedge_index[1].unique().shape[0]
+
+    assert torch.equal(result.hyperedge_index, expected_hyperedge_index)
+    assert result.x.shape[0] == expected_num_nodes
+    assert result.y.shape[0] == expected_num_hyperedges
+    assert utils.to_non_empty_edgeattr(result.hyperedge_attr).shape[0] == expected_num_hyperedges
+
+
+@pytest.mark.parametrize(
+    "hyperedge_index, k, x, expected_x",
+    [
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[10.0], [20.0], [30.0], [40.0], [50.0]]),
+            torch.tensor([[30.0], [40.0], [50.0]]),
+            id="disjoint_nodes_first_hyperedge_removed",
+        ),
+        pytest.param(
+            # Hyperedge 0: nodes {0, 2} -> 2 nodes (removed), hyperedge 1: nodes {1, 2, 3} -> 3 nodes (kept)
+            # Node 2 is shared, so it survives because hyperedge 1 is kept
+            # Node 0 is the only node removed as it is only in the removed hyperedge 0
+            torch.tensor([[0, 2, 1, 2, 3], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[10.0], [20.0], [30.0], [40.0]]),
+            torch.tensor([[20.0], [30.0], [40.0]]),
+            id="shared_node_survives_with_kept_hyperedge",
+        ),
+    ],
+)
+def test_remove_hyperedges_with_fewer_than_k_nodes_subsets_x(hyperedge_index, k, x, expected_x):
+    hdata = HData(x=x, hyperedge_index=hyperedge_index)
+    result = hdata.remove_hyperedges_with_fewer_than_k_nodes(k=k)
+
+    assert torch.equal(result.x, expected_x)
+
+
+@pytest.mark.parametrize(
+    "hyperedge_index, k, y, expected_y",
+    [
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([1.0, 0.0]),
+            torch.tensor([0.0]),
+            id="disjoint_nodes_first_hyperedge_removed",
+        ),
+        pytest.param(
+            # Hyperedge 0: nodes {0, 2} -> 2 nodes (removed). hyperedge 1: nodes {1, 2, 3} -> 3 nodes (kept)
+            # Node 2 is shared, so y for hyperedge 1 must survive
+            torch.tensor([[0, 2, 1, 2, 3], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([1.0, 0.0]),
+            torch.tensor([0.0]),
+            id="shared_node_y_of_kept_hyperedge_survives",
+        ),
+    ],
+)
+def test_remove_hyperedges_with_fewer_than_k_nodes_subsets_y(hyperedge_index, k, y, expected_y):
+    num_nodes = hyperedge_index[0].max().item() + 1
+    x = torch.randn(num_nodes, 2)
+    hdata = HData(x=x, hyperedge_index=hyperedge_index, y=y)
+    result = hdata.remove_hyperedges_with_fewer_than_k_nodes(k=k)
+
+    assert torch.equal(result.y, expected_y)
+
+
+@pytest.mark.parametrize(
+    "hyperedge_index, k, hyperedge_attr, expected_attr",
+    [
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            torch.tensor([[3.0, 4.0]]),
+            id="disjoint_nodes_first_hyperedge_removed",
+        ),
+        pytest.param(
+            # Hyperedge 0: nodes {0, 2} -> 2 nodes (removed), hyperedge 1: nodes {1, 2, 3} -> 3 nodes (kept)
+            # Node 2 is shared, so attr for hyperedge 1 must survive
+            torch.tensor([[0, 2, 1, 2, 3], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            torch.tensor([[3.0, 4.0]]),
+            id="shared_node_attr_of_kept_hyperedge_survives",
+        ),
+    ],
+)
+def test_remove_hyperedges_with_fewer_than_k_nodes_subsets_hyperedge_attr(
+    hyperedge_index, k, hyperedge_attr, expected_attr
+):
+    num_nodes = hyperedge_index[0].max().item() + 1
+    x = torch.randn(num_nodes, 2)
+    hdata = HData(x=x, hyperedge_index=hyperedge_index, hyperedge_attr=hyperedge_attr)
+    result = hdata.remove_hyperedges_with_fewer_than_k_nodes(k=k)
+
+    assert result.hyperedge_attr is not None
+    assert torch.equal(result.hyperedge_attr, expected_attr)
+
+
+def test_remove_hyperedges_with_fewer_than_k_nodes_keeps_none_hyperedge_attr():
+    x = torch.randn(3, 2)
+    hyperedge_index = torch.tensor([[0, 1, 2], [0, 0, 0]])
+    hdata = HData(x=x, hyperedge_index=hyperedge_index, hyperedge_attr=None)
+
+    result = hdata.remove_hyperedges_with_fewer_than_k_nodes(k=1)
+
+    assert result.hyperedge_attr is None
+
+
+def test_remove_hyperedges_with_fewer_than_k_nodes_rebases_hyperedge_index():
+    # Hyperedge 0 (nodes 0,1) removed, while hyperedge 1 (nodes 2,3,4) kept.
+    # After filtering, surviving nodes 2, 3, and 4, and hyperedge 1 must be rebased to 0-based.
+    x = torch.randn(5, 2)
+    hyperedge_index = torch.tensor([[0, 1, 2, 3, 4], [0, 0, 1, 1, 1]])
+    hdata = HData(x=x, hyperedge_index=hyperedge_index)
+
+    result = hdata.remove_hyperedges_with_fewer_than_k_nodes(k=3)
+
+    assert torch.equal(result.hyperedge_index, torch.tensor([[0, 1, 2], [0, 0, 0]]))
 
 
 def test_stats_with_empty_hdata():

--- a/hyperbench/tests/types/hypergraph_test.py
+++ b/hyperbench/tests/types/hypergraph_test.py
@@ -623,3 +623,81 @@ def test_reduce_to_graph_raises_on_single_node_hyperedge():
 
     with pytest.raises(ValueError, match="The number of vertices in an hyperedge must be >= 2."):
         HyperedgeIndex(hyperedge_index).reduce_to_edge_index_on_random_direction(x)
+
+
+@pytest.mark.parametrize(
+    "hyperedge_index_tensor, k, expected_tensor",
+    [
+        pytest.param(
+            torch.zeros((2, 0), dtype=torch.long),
+            1,
+            torch.zeros((2, 0), dtype=torch.long),
+            id="empty_index",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            1,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="single_hyperedge_3_nodes_k1_all_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            3,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="single_hyperedge_3_nodes_k3_exact_boundary_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            4,
+            torch.zeros((2, 0), dtype=torch.long),
+            id="single_hyperedge_3_nodes_k4_removed",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]]),
+            2,
+            torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]]),
+            id="two_hyperedges_2_nodes_each_k2_both_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]]),
+            3,
+            torch.zeros((2, 0), dtype=torch.long),
+            id="two_hyperedges_2_nodes_each_k3_both_removed",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 0, 1, 1]]),
+            3,
+            torch.tensor([[0, 1, 2], [0, 0, 0]]),
+            id="two_hyperedges_first_3_nodes_second_2_nodes_k3_only_first_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4], [0, 0, 1, 1, 1]]),
+            3,
+            torch.tensor([[2, 3, 4], [1, 1, 1]]),
+            id="two_hyperedges_first_2_nodes_second_3_nodes_k3_only_second_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 1, 1, 1, 2]]),
+            3,
+            torch.tensor([[2, 3, 4], [1, 1, 1]]),
+            id="three_hyperedges_sizes_2_3_1_k3_only_middle_kept",
+        ),
+        pytest.param(
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 0, 1, 1, 1]]),
+            2,
+            torch.tensor([[0, 1, 2, 3, 4, 5], [0, 0, 0, 1, 1, 1]]),
+            id="two_hyperedges_3_nodes_each_k2_both_kept",
+        ),
+    ],
+)
+def test_remove_hyperedges_with_fewer_than_k_nodes(hyperedge_index_tensor, k, expected_tensor):
+    result = HyperedgeIndex(hyperedge_index_tensor).remove_hyperedges_with_fewer_than_k_nodes(k)
+
+    assert torch.equal(result.item, expected_tensor)
+
+
+def test_remove_hyperedges_with_fewer_than_k_nodes_returns_self():
+    hyperedge_index = HyperedgeIndex(torch.tensor([[0, 1, 2], [0, 0, 0]]))
+    result = hyperedge_index.remove_hyperedges_with_fewer_than_k_nodes(1)
+
+    assert result is hyperedge_index

--- a/hyperbench/train/trainer.py
+++ b/hyperbench/train/trainer.py
@@ -306,7 +306,7 @@ class MultiModelTrainer:
                 self.__tensorboard_process = self.__start_tensorboard_process()
             else:
                 warnings.warn(
-                    "TensorBoard is not available."
+                    "TensorBoard is not available. "
                     "Install it with `pip install hyperbench[tensorboard]` or `pip install tensorboard`"
                     "to enable auto-start.",
                     category=UserWarning,

--- a/hyperbench/types/hdata.py
+++ b/hyperbench/types/hdata.py
@@ -251,7 +251,7 @@ class HData:
         self,
         enricher: NodeFeatureEnricher,
         enrichment_mode: Optional[EnrichmentMode] = None,
-    ) -> None:
+    ) -> "HData":
         """
         Enrich node features using the provided node feature enricher.
 
@@ -265,9 +265,18 @@ class HData:
 
         match enrichment_mode:
             case "concatenate":
-                self.x = torch.cat([self.x, enriched_features], dim=1)
+                x = torch.cat([self.x, enriched_features], dim=1)
             case _:
-                self.x = enriched_features
+                x = enriched_features
+
+        return self.__class__(
+            x=x,
+            hyperedge_index=self.hyperedge_index,
+            hyperedge_attr=self.hyperedge_attr,
+            num_nodes=self.num_nodes,
+            num_hyperedges=self.num_hyperedges,
+            y=self.y,
+        )
 
     def get_device_if_all_consistent(self) -> torch.device:
         """
@@ -287,6 +296,27 @@ class HData:
             raise ValueError(f"Inconsistent device placement: {devices}")
 
         return devices.pop() if len(devices) == 1 else torch.device("cpu")
+
+    def remove_hyperedges_with_fewer_than_k_nodes(self, k: int) -> "HData":
+        hyperedge_index_wrapper = HyperedgeIndex(
+            self.hyperedge_index
+        ).remove_hyperedges_with_fewer_than_k_nodes(k)
+
+        x = self.x[hyperedge_index_wrapper.node_ids]
+        y = self.y[hyperedge_index_wrapper.hyperedge_ids]
+
+        hyperedge_attr = None
+        if self.hyperedge_attr is not None:
+            hyperedge_attr = self.hyperedge_attr[hyperedge_index_wrapper.hyperedge_ids]
+
+        return self.__class__(
+            x=x,
+            hyperedge_index=hyperedge_index_wrapper.to_0based().item,
+            hyperedge_attr=hyperedge_attr,
+            num_nodes=hyperedge_index_wrapper.num_nodes,
+            num_hyperedges=hyperedge_index_wrapper.num_hyperedges,
+            y=y,
+        )
 
     def shuffle(self, seed: Optional[int] = None) -> "HData":
         """
@@ -346,7 +376,7 @@ class HData:
         #          -> new_y = [y[1], y[2], y[0]] = [1, 0, 1]
         new_y = self.y[permutation]
 
-        return HData(
+        return self.__class__(
             x=self.x,
             hyperedge_index=new_hyperedge_index,
             hyperedge_attr=new_hyperedge_attr,
@@ -386,7 +416,7 @@ class HData:
         Returns:
             A new :class:`HData` instance with the same attributes except for y, which is set to a tensor of the given value.
         """
-        return HData(
+        return self.__class__(
             x=self.x,
             hyperedge_index=self.hyperedge_index,
             hyperedge_attr=self.hyperedge_attr,

--- a/hyperbench/types/hypergraph.py
+++ b/hyperbench/types/hypergraph.py
@@ -556,6 +556,43 @@ class HyperedgeIndex:
         self.__hyperedge_index = torch.unique(self.__hyperedge_index, dim=1).contiguous()
         return self
 
+    def remove_hyperedges_with_fewer_than_k_nodes(self, k: int) -> "HyperedgeIndex":
+        """
+        Remove hyperedges that contain fewer than k nodes.
+
+        Example:
+            >>> hyperedge_index = [[0, 1, 2, 3, 5, 4],
+            ...                    [0, 0, 1, 1, 2, 1]], shape (2, |E| = 6)
+
+            >>> k = 3
+            >>> unique_hyperedge_ids: [0, 1, 2]
+            ... # inverse -> idx_to_hyperedge_id, counts -> num_nodes_per_hyperedge
+            ... inverse           = [0, 0, 1, 1, 2, 1]  # (index into unique_hyperedge_ids per column)
+            ... counts            = [2, 3, 1]
+            >>> # counts[inverse] is equivalent to:
+            ... # for i, inv in enumerate(inverse): keep_mask[i] = counts[inv]
+            >>> counts[inverse]   = [2, 2, 3, 3, 1, 3]
+            >>> keep_mask         = [F, F, T, T, F, T]
+
+            >>> # after filtering hyperedges with fewer than k=3 nodes:
+            >>> hyperedge_index = [[2, 3, 4],
+            ...                    [1, 1, 1]], shape (2, |E'| = 3)
+
+        Args:
+            k: The minimum number of nodes a hyperedge must contain to be kept.
+
+        Returns:
+            A new :class:`HyperedgeIndex` instance with hyperedges containing fewer than k nodes.
+        """
+        _, idx_to_hyperedge_id, num_nodes_per_hyperedge = torch.unique(
+            self.all_hyperedge_ids,
+            return_inverse=True,
+            return_counts=True,
+        )
+        keep_mask = num_nodes_per_hyperedge[idx_to_hyperedge_id] >= k
+        self.__hyperedge_index = self.__hyperedge_index[:, keep_mask]
+        return self
+
     def to_0based(
         self,
         node_ids_to_rebase: Optional[Tensor] = None,


### PR DESCRIPTION
### All Submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Added a method in the `HyperedgeIndex` class to remove hyperedges of cardinality `c` from the hyperedge index.
- Added wrappers in `HData` and `Dataset`.
- Added `update_from_hdata` method for when you don't need the class method.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make lint`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
- [x] Have you added an explanation of what your changes are and why you'd like us to include them?
