### PR TITLE
Clone tensors in HData "return new instance" methods

### DIFF
--- a/hyperbench/tests/types/hdata_test.py
+++ b/hyperbench/tests/types/hdata_test.py
@@ -1498,3 +1498,161 @@ def test_stats_with_empty_hdata():
     stats = empty_hdata.stats()
 
     assert stats == expected_stats
+
+
+# ---------------------------------------------------------------------------
+# Storage-isolation regression tests for issue #172.
+#
+# Methods that return a new HData used to retain references to mutable tensors
+# from the source object, so mutating the returned object also mutated the
+# original. These tests pin down the contract: derived instances must own
+# their tensor storage.
+# ---------------------------------------------------------------------------
+
+
+def _hdata_with_all_optional_fields():
+    """Build an HData populated with every optional tensor field.
+
+    Used by the storage-isolation tests so each test exercises every field
+    a derived method might re-use without cloning.
+    """
+    return HData(
+        x=torch.randn(5, 4),
+        hyperedge_index=torch.tensor([[0, 1, 2, 3, 4, 0], [0, 0, 1, 1, 2, 2]]),
+        hyperedge_weights=torch.randn(3),
+        hyperedge_attr=torch.randn(3, 2),
+        global_node_ids=torch.tensor([10, 20, 30, 40, 50]),
+        y=torch.tensor([1.0, 0.0, 1.0]),
+    )
+
+
+def test_with_y_to_does_not_share_tensor_storage():
+    src = _hdata_with_all_optional_fields()
+    derived = src.with_y_zeros()
+
+    assert derived.x.data_ptr() != src.x.data_ptr()
+    assert derived.hyperedge_index.data_ptr() != src.hyperedge_index.data_ptr()
+    assert derived.hyperedge_weights.data_ptr() != src.hyperedge_weights.data_ptr()
+    assert derived.hyperedge_attr.data_ptr() != src.hyperedge_attr.data_ptr()
+    assert derived.global_node_ids.data_ptr() != src.global_node_ids.data_ptr()
+
+
+def test_with_y_to_mutating_derived_does_not_affect_source():
+    src = _hdata_with_all_optional_fields()
+    src_x_snapshot = src.x.clone()
+    src_hyperedge_index_snapshot = src.hyperedge_index.clone()
+
+    derived = src.with_y_zeros()
+    derived.x.add_(1.0)
+    derived.hyperedge_index.fill_(99)
+
+    assert torch.equal(src.x, src_x_snapshot)
+    assert torch.equal(src.hyperedge_index, src_hyperedge_index_snapshot)
+
+
+def test_split_transductive_does_not_share_x_or_global_node_ids():
+    src = _hdata_with_all_optional_fields()
+    src_x_snapshot = src.x.clone()
+    src_global_node_ids_snapshot = src.global_node_ids.clone()
+
+    derived = HData.split(
+        src,
+        split_hyperedge_ids=torch.tensor([1]),
+        node_space_setting="transductive",
+    )
+
+    assert derived.x.data_ptr() != src.x.data_ptr()
+    assert derived.global_node_ids.data_ptr() != src.global_node_ids.data_ptr()
+
+    derived.x.add_(1.0)
+    derived.global_node_ids.fill_(0)
+
+    assert torch.equal(src.x, src_x_snapshot)
+    assert torch.equal(src.global_node_ids, src_global_node_ids_snapshot)
+
+
+def test_cat_same_node_space_does_not_share_x_or_global_node_ids():
+    src = _hdata_with_all_optional_fields()
+    src_x_snapshot = src.x.clone()
+    src_global_node_ids_snapshot = src.global_node_ids.clone()
+
+    other = HData(
+        x=torch.randn(3, 4),
+        hyperedge_index=torch.tensor([[0, 2], [3, 3]]),
+        global_node_ids=torch.tensor([10, 30, 50]),
+        y=torch.tensor([1.0]),
+    )
+
+    derived = HData.cat_same_node_space([src, other])
+
+    # x and global_node_ids on the result come from the largest input
+    # (`src` here), so this is the case the issue calls out.
+    assert derived.x.data_ptr() != src.x.data_ptr()
+    assert derived.global_node_ids.data_ptr() != src.global_node_ids.data_ptr()
+
+    derived.x.add_(1.0)
+    derived.global_node_ids.fill_(0)
+
+    assert torch.equal(src.x, src_x_snapshot)
+    assert torch.equal(src.global_node_ids, src_global_node_ids_snapshot)
+
+
+def test_shuffle_does_not_share_x_or_global_node_ids():
+    src = _hdata_with_all_optional_fields()
+    src_x_snapshot = src.x.clone()
+    src_global_node_ids_snapshot = src.global_node_ids.clone()
+
+    derived = src.shuffle(seed=42)
+    derived.x.add_(1.0)
+    derived.global_node_ids.fill_(0)
+
+    assert torch.equal(src.x, src_x_snapshot)
+    assert torch.equal(src.global_node_ids, src_global_node_ids_snapshot)
+
+
+def test_enrich_hyperedge_weights_does_not_share_other_tensors():
+    src = _hdata_with_all_optional_fields()
+    src_x_snapshot = src.x.clone()
+    src_hyperedge_index_snapshot = src.hyperedge_index.clone()
+
+    enricher = MagicMock(spec=HyperedgeEnricher)
+    enricher.enrich.return_value = torch.tensor([0.5, 0.5, 0.5])
+
+    derived = src.enrich_hyperedge_weights(enricher)
+    derived.x.add_(1.0)
+    derived.hyperedge_index.fill_(99)
+
+    assert torch.equal(src.x, src_x_snapshot)
+    assert torch.equal(src.hyperedge_index, src_hyperedge_index_snapshot)
+
+
+def test_enrich_hyperedge_attr_does_not_share_other_tensors():
+    src = _hdata_with_all_optional_fields()
+    src_x_snapshot = src.x.clone()
+    src_hyperedge_index_snapshot = src.hyperedge_index.clone()
+
+    enricher = MagicMock(spec=HyperedgeEnricher)
+    enricher.enrich.return_value = torch.randn(3, 2)
+
+    derived = src.enrich_hyperedge_attr(enricher)
+    derived.x.add_(1.0)
+    derived.hyperedge_index.fill_(99)
+
+    assert torch.equal(src.x, src_x_snapshot)
+    assert torch.equal(src.hyperedge_index, src_hyperedge_index_snapshot)
+
+
+def test_enrich_node_features_does_not_share_other_tensors():
+    src = _hdata_with_all_optional_fields()
+    src_hyperedge_index_snapshot = src.hyperedge_index.clone()
+    src_y_snapshot = src.y.clone()
+
+    enricher = MagicMock(spec=NodeEnricher)
+    enricher.enrich.return_value = torch.randn(5, 8)
+
+    derived = src.enrich_node_features(enricher)
+    derived.hyperedge_index.fill_(99)
+    derived.y.fill_(99.0)
+
+    assert torch.equal(src.hyperedge_index, src_hyperedge_index_snapshot)
+    assert torch.equal(src.y, src_y_snapshot)

--- a/hyperbench/types/hdata.py
+++ b/hyperbench/types/hdata.py
@@ -16,6 +16,17 @@ from hyperbench.nn.enricher import EnrichmentMode, NodeEnricher, HyperedgeEnrich
 from hyperbench.types.hypergraph import HyperedgeIndex
 
 
+def _clone_optional(t: Optional[Tensor]) -> Optional[Tensor]:
+    """Clone ``t`` defensively, or return ``None`` if it is ``None``.
+
+    Used by the :class:`HData` "return a new instance" helpers so that
+    derived instances don't share mutable tensor storage with their source.
+    Mutating a tensor on the returned object must not silently mutate the
+    same tensor on the original (issue #172).
+    """
+    return None if t is None else t.clone()
+
+
 class HData:
     """
     Container for hypergraph data.
@@ -149,7 +160,15 @@ class HData:
                 "Overlapping hyperedge IDs found across instances. Ensure each instance uses distinct hyperedge IDs."
             )
 
-        new_x = x if x is not None else max(hdatas, key=lambda hdata: hdata.num_nodes).x
+        # When x is taken from one of the inputs we clone it so the returned
+        # HData has independent storage from the source — mutations on the
+        # concatenated instance must not bleed back into the original input
+        # it was sourced from (issue #172). When the caller passes x in
+        # explicitly we trust them to own its lifetime.
+        new_x = (
+            x if x is not None
+            else max(hdatas, key=lambda hdata: hdata.num_nodes).x.clone()
+        )
         new_y = torch.cat([hdata.y for hdata in hdatas], dim=0)
         new_hyperedge_index = torch.cat([hdata.hyperedge_index for hdata in hdatas], dim=1)
 
@@ -166,6 +185,8 @@ class HData:
         new_hyperedge_weights = (
             torch.cat(hyperedge_weights, dim=0) if len(hyperedge_weights) > 0 else None
         )
+        # global_node_ids is sourced from one of the inputs, so clone it for
+        # the same reason as new_x above (issue #172).
         return cls(
             x=new_x,
             hyperedge_index=new_hyperedge_index,
@@ -173,7 +194,9 @@ class HData:
             hyperedge_attr=new_hyperedge_attr,
             num_nodes=new_x.size(0),
             num_hyperedges=new_y.size(0),
-            global_node_ids=max(hdatas, key=lambda hdata: hdata.num_nodes).global_node_ids,
+            global_node_ids=_clone_optional(
+                max(hdatas, key=lambda hdata: hdata.num_nodes).global_node_ids,
+            ),
             y=new_y,
         )
 
@@ -291,14 +314,17 @@ class HData:
                 original_ids=split_hyperedge_index[1],
                 ids_to_rebase=split_unique_hyperedge_ids,
             )
+            # x and global_node_ids are reused unchanged in transductive mode;
+            # clone them so the split instance doesn't share storage with the
+            # parent and mutations on either side stay isolated (issue #172).
             return cls(
-                x=hdata.x,
+                x=hdata.x.clone(),
                 hyperedge_index=split_hyperedge_index,
                 hyperedge_weights=split_hyperedge_weights,
                 hyperedge_attr=split_hyperedge_attr,
                 num_nodes=hdata.num_nodes,
                 num_hyperedges=len(split_unique_hyperedge_ids),
-                global_node_ids=hdata.global_node_ids,
+                global_node_ids=_clone_optional(hdata.global_node_ids),
                 y=split_y,
             )
 
@@ -355,15 +381,18 @@ class HData:
             case _:
                 x = enriched_features
 
+        # x is freshly produced (either by the enricher or by torch.cat), so
+        # it doesn't alias self.x; the rest of the tensors are cloned so the
+        # returned instance has independent storage from self (issue #172).
         return self.__class__(
             x=x,
-            hyperedge_index=self.hyperedge_index,
-            hyperedge_weights=self.hyperedge_weights,
-            hyperedge_attr=self.hyperedge_attr,
+            hyperedge_index=self.hyperedge_index.clone(),
+            hyperedge_weights=_clone_optional(self.hyperedge_weights),
+            hyperedge_attr=_clone_optional(self.hyperedge_attr),
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
-            global_node_ids=self.global_node_ids,
-            y=self.y,
+            global_node_ids=_clone_optional(self.global_node_ids),
+            y=_clone_optional(self.y),
         )
 
     def enrich_node_features_from(
@@ -470,15 +499,18 @@ class HData:
 
         enriched_x = torch.stack(enriched_rows, dim=0).to(device=self.device)
 
+        # enriched_x is freshly stacked so it doesn't alias either source's
+        # tensors; the remaining fields are cloned so the returned instance
+        # has independent storage from self (issue #172).
         return self.__class__(
             x=enriched_x,
-            hyperedge_index=self.hyperedge_index,
-            hyperedge_weights=self.hyperedge_weights,
-            hyperedge_attr=self.hyperedge_attr,
+            hyperedge_index=self.hyperedge_index.clone(),
+            hyperedge_weights=_clone_optional(self.hyperedge_weights),
+            hyperedge_attr=_clone_optional(self.hyperedge_attr),
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
-            global_node_ids=self.global_node_ids,
-            y=self.y,
+            global_node_ids=_clone_optional(self.global_node_ids),
+            y=_clone_optional(self.y),
         )
 
     def enrich_hyperedge_weights(
@@ -505,15 +537,18 @@ class HData:
             case _:
                 hyperedge_weights = enriched_weights
 
+        # hyperedge_weights is freshly produced (enricher or torch.cat). The
+        # rest of the tensors are cloned so the returned instance has
+        # independent storage from self (issue #172).
         return self.__class__(
-            x=self.x,
-            hyperedge_index=self.hyperedge_index,
+            x=self.x.clone(),
+            hyperedge_index=self.hyperedge_index.clone(),
             hyperedge_weights=hyperedge_weights,
-            hyperedge_attr=self.hyperedge_attr,
+            hyperedge_attr=_clone_optional(self.hyperedge_attr),
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
-            global_node_ids=self.global_node_ids,
-            y=self.y,
+            global_node_ids=_clone_optional(self.global_node_ids),
+            y=_clone_optional(self.y),
         )
 
     def enrich_hyperedge_attr(
@@ -542,15 +577,18 @@ class HData:
             case _:
                 hyperedge_attr = enriched_features
 
+        # hyperedge_attr is freshly produced (enricher or torch.cat). The
+        # rest of the tensors are cloned so the returned instance has
+        # independent storage from self (issue #172).
         return self.__class__(
-            x=self.x,
-            hyperedge_index=self.hyperedge_index,
-            hyperedge_weights=self.hyperedge_weights,
+            x=self.x.clone(),
+            hyperedge_index=self.hyperedge_index.clone(),
+            hyperedge_weights=_clone_optional(self.hyperedge_weights),
             hyperedge_attr=hyperedge_attr,
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
-            global_node_ids=self.global_node_ids,
-            y=self.y,
+            global_node_ids=_clone_optional(self.global_node_ids),
+            y=_clone_optional(self.y),
         )
 
     def get_device_if_all_consistent(self) -> torch.device:
@@ -668,14 +706,19 @@ class HData:
         #          -> new_y = [y[1], y[2], y[0]] = [1, 0, 1]
         new_y = self.y[permutation]
 
+        # x and global_node_ids are not changed by shuffle so they used to be
+        # passed by reference; clone them so callers can mutate the returned
+        # instance without affecting the original (issue #172). The other
+        # fields here (new_hyperedge_index, new_y, etc.) are already produced
+        # by clone/permute and don't alias self.
         return self.__class__(
-            x=self.x,
+            x=self.x.clone(),
             hyperedge_index=new_hyperedge_index,
             hyperedge_weights=new_hyperedge_weights,
             hyperedge_attr=new_hyperedge_attr,
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
-            global_node_ids=self.global_node_ids,
+            global_node_ids=_clone_optional(self.global_node_ids),
             y=new_y,
         )
 
@@ -718,14 +761,17 @@ class HData:
         Returns:
             A new :class:`HData` instance with the same attributes except for y, which is set to a tensor of the given value.
         """
+        # Tensors are cloned so the returned instance has independent storage —
+        # mutating its hyperedge_index, x, etc. must not bleed back into self
+        # (see issue #172).
         return self.__class__(
-            x=self.x,
-            hyperedge_index=self.hyperedge_index,
-            hyperedge_weights=self.hyperedge_weights,
-            hyperedge_attr=self.hyperedge_attr,
+            x=self.x.clone(),
+            hyperedge_index=self.hyperedge_index.clone(),
+            hyperedge_weights=_clone_optional(self.hyperedge_weights),
+            hyperedge_attr=_clone_optional(self.hyperedge_attr),
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
-            global_node_ids=self.global_node_ids,
+            global_node_ids=_clone_optional(self.global_node_ids),
             y=torch.full((self.num_hyperedges,), value, dtype=torch.float, device=self.device),
         )
 


### PR DESCRIPTION
## Summary

Closes #172.

Several \`HData\` methods returned a new instance but retained references
to mutable tensors from the source object, so mutating the returned
object also mutated the original. The audit in the issue body matches
what I see in the code — confirmed surfaces:

- \`with_y_to\` (and its \`with_y_zeros\` / \`with_y_ones\` wrappers)
  reused \`x\`, \`hyperedge_index\`, \`hyperedge_weights\`,
  \`hyperedge_attr\`, and \`global_node_ids\`.
- \`enrich_node_features\` reused \`hyperedge_index\`,
  \`hyperedge_weights\`, \`hyperedge_attr\`, \`global_node_ids\`, and
  \`y\` (only \`x\` is freshly produced).
- \`enrich_node_features_from\` reused everything except the freshly
  stacked \`enriched_x\`.
- \`enrich_hyperedge_weights\` and \`enrich_hyperedge_attr\` reused all
  non-enriched tensors.
- \`shuffle\` reused \`x\` and \`global_node_ids\` (the others were
  already cloned/permuted).
- \`split\` in transductive mode reused \`x\` and \`global_node_ids\`.
- \`cat_same_node_space\` reused \`x\` (when not provided explicitly)
  and \`global_node_ids\` from the input with the largest node count.

## Fix

Mechanical: introduce a small module-level \`_clone_optional\` helper
and call \`.clone()\` on every reused tensor so each \"return new
instance\" helper hands back independent storage. Tensors that are
computed fresh (e.g. \`enricher.enrich(...)\`, \`torch.cat(...)\`,
\`torch.stack(...)\`) are left alone — they don't alias anything.

In \`cat_same_node_space\`, when the caller passes \`x\` explicitly we
trust them to own its lifetime and don't clone (consistent with the
existing API contract); the implicit \`max(...).x\` and
\`max(...).global_node_ids\` paths now clone.

\`HyperedgeIndex.to_0based()\` is intentionally in-place and is
out of scope here.

## Test plan

Eight regression tests added in \`hyperbench/tests/types/hdata_test.py\`:

- \`test_with_y_to_does_not_share_tensor_storage\` — data-pointer
  inequality across \`x\`, \`hyperedge_index\`, \`hyperedge_weights\`,
  \`hyperedge_attr\`, \`global_node_ids\`.
- \`test_with_y_to_mutating_derived_does_not_affect_source\` —
  mutation isolation.
- \`test_split_transductive_does_not_share_x_or_global_node_ids\`
- \`test_cat_same_node_space_does_not_share_x_or_global_node_ids\`
- \`test_shuffle_does_not_share_x_or_global_node_ids\`
- \`test_enrich_hyperedge_weights_does_not_share_other_tensors\`
- \`test_enrich_hyperedge_attr_does_not_share_other_tensors\`
- \`test_enrich_node_features_does_not_share_other_tensors\`

Each new test fails when only \`hdata.py\` is reverted, confirming they
exercise the new behaviour. The full \`hdata_test.py\` suite passes
(113 prior + 8 new = 121); broader \`hyperbench/tests/\` runs pass
(730 passed, 5 skipped) except for an unrelated
\`markdown_logger_test.py\` collection error caused by a missing
\`griffe\` dev dependency in my local env (reproduces on \`main\`
without these changes).

## Commit / branch hygiene

- Branch: \`fix/hdata-shared-mutable-tensors\` (matches the
  \`(feat|fix|...)/[a-z0-9]+(-[a-z0-9]+)*\` pattern from
  \`CONTRIBUTING.md\`).
- Commit: conventional commit \`fix: ...\`.