### PR TITLE
DataLoader.collate now clones cached HData when sampling full hypergraph

### DIFF
--- a/hyperbench/data/loader.py
+++ b/hyperbench/data/loader.py
@@ -71,7 +71,12 @@ class DataLoader(TorchDataLoader):
             A single :class:`HData` object containing the collated data.
         """
         if self.__sample_full_hypergraph:
-            return self.__cached_dataset_hdata.to(batch[0].device)
+            # `HData.to` is in-place, so without `clone()` the dataloader
+            # would return the cached dataset object itself — meaning any
+            # downstream mutation (or device transfer through a different
+            # path on the next iteration) would silently mutate shared
+            # dataset state. See issue #173.
+            return self.__cached_dataset_hdata.clone().to(batch[0].device)
 
         collated_hyperedge_index = torch.cat([data.hyperedge_index for data in batch], dim=1)
         hyperedge_index_wrapper = HyperedgeIndex(collated_hyperedge_index).remove_duplicate_edges()

--- a/hyperbench/data/loader.py
+++ b/hyperbench/data/loader.py
@@ -71,11 +71,6 @@ class DataLoader(TorchDataLoader):
             A single :class:`HData` object containing the collated data.
         """
         if self.__sample_full_hypergraph:
-            # `HData.to` is in-place, so without `clone()` the dataloader
-            # would return the cached dataset object itself — meaning any
-            # downstream mutation (or device transfer through a different
-            # path on the next iteration) would silently mutate shared
-            # dataset state. See issue #173.
             return self.__cached_dataset_hdata.clone().to(batch[0].device)
 
         collated_hyperedge_index = torch.cat([data.hyperedge_index for data in batch], dim=1)

--- a/hyperbench/tests/data/loader_test.py
+++ b/hyperbench/tests/data/loader_test.py
@@ -451,3 +451,72 @@ def test_collate_with_node_sampled_batch():
     assert torch.equal(batched.hyperedge_index, expected_hyperedge_index)
 
     assert batched.hyperedge_attr is None
+
+
+# ---------------------------------------------------------------------------
+# Storage-isolation regression tests for issue #173.
+#
+# When sample_full_hypergraph=True, DataLoader.collate() used to return
+# `self.__cached_dataset_hdata.to(batch[0].device)`. Because HData.to() is
+# in-place, that returned the cached dataset object itself — so iterating
+# the dataloader and mutating the batch (or moving it through a different
+# code path on the next iteration) silently mutated the dataset's cached
+# hdata.
+# ---------------------------------------------------------------------------
+
+
+def test_collate_sample_full_hypergraph_does_not_share_storage_with_cached_hdata(
+    mock_dataset_single_sample,
+):
+    loader = DataLoader(mock_dataset_single_sample, sample_full_hypergraph=True)
+
+    batched = loader.collate([mock_dataset_single_sample[0]])
+
+    cached: HData = mock_dataset_single_sample.hdata
+    assert batched is not cached
+    # The most-likely-mutated tensors must not share storage with the
+    # cached dataset, otherwise a downstream caller mutating the batch
+    # would corrupt the dataset.
+    assert batched.x.data_ptr() != cached.x.data_ptr()
+    assert batched.hyperedge_index.data_ptr() != cached.hyperedge_index.data_ptr()
+    assert batched.hyperedge_attr is not None
+    assert batched.hyperedge_attr.data_ptr() != cached.hyperedge_attr.data_ptr()
+
+
+def test_collate_sample_full_hypergraph_mutating_batch_does_not_affect_cached_hdata(
+    mock_dataset_single_sample,
+):
+    cached: HData = mock_dataset_single_sample.hdata
+    cached_x_snapshot = cached.x.clone()
+    cached_hyperedge_index_snapshot = cached.hyperedge_index.clone()
+    cached_hyperedge_attr_snapshot = cached.hyperedge_attr.clone()
+
+    loader = DataLoader(mock_dataset_single_sample, sample_full_hypergraph=True)
+    batched = loader.collate([mock_dataset_single_sample[0]])
+
+    batched.x.add_(1.0)
+    batched.hyperedge_index.fill_(99)
+    batched.hyperedge_attr.add_(1.0)
+
+    assert torch.equal(cached.x, cached_x_snapshot)
+    assert torch.equal(cached.hyperedge_index, cached_hyperedge_index_snapshot)
+    assert torch.equal(cached.hyperedge_attr, cached_hyperedge_attr_snapshot)
+
+
+def test_collate_sample_full_hypergraph_with_weights_isolates_weights(
+    mock_dataset_single_sample_with_weights,
+):
+    cached: HData = mock_dataset_single_sample_with_weights.hdata
+    cached_weights_snapshot = cached.hyperedge_weights.clone()
+
+    loader = DataLoader(
+        mock_dataset_single_sample_with_weights, sample_full_hypergraph=True,
+    )
+    batched = loader.collate([mock_dataset_single_sample_with_weights[0]])
+
+    assert batched.hyperedge_weights is not None
+    assert batched.hyperedge_weights.data_ptr() != cached.hyperedge_weights.data_ptr()
+
+    batched.hyperedge_weights.fill_(0.0)
+
+    assert torch.equal(cached.hyperedge_weights, cached_weights_snapshot)

--- a/hyperbench/tests/data/loader_test.py
+++ b/hyperbench/tests/data/loader_test.py
@@ -13,7 +13,13 @@ def mock_dataset_single_sample():
     x = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
     hyperedge_index = torch.tensor([[0, 1, 1, 2], [0, 0, 1, 1]])
     hyperedge_attr = torch.tensor([[0.5], [0.7]])
-    hdata = HData(x=x, hyperedge_index=hyperedge_index, hyperedge_attr=hyperedge_attr)
+    hyperedge_weights = torch.tensor([[0.8], [0.9]])
+    hdata = HData(
+        x=x,
+        hyperedge_index=hyperedge_index,
+        hyperedge_attr=hyperedge_attr,
+        hyperedge_weights=hyperedge_weights,
+    )
 
     dataset = MagicMock(spec=Dataset)
     dataset.hdata = hdata
@@ -453,18 +459,6 @@ def test_collate_with_node_sampled_batch():
     assert batched.hyperedge_attr is None
 
 
-# ---------------------------------------------------------------------------
-# Storage-isolation regression tests for issue #173.
-#
-# When sample_full_hypergraph=True, DataLoader.collate() used to return
-# `self.__cached_dataset_hdata.to(batch[0].device)`. Because HData.to() is
-# in-place, that returned the cached dataset object itself — so iterating
-# the dataloader and mutating the batch (or moving it through a different
-# code path on the next iteration) silently mutated the dataset's cached
-# hdata.
-# ---------------------------------------------------------------------------
-
-
 def test_collate_sample_full_hypergraph_does_not_share_storage_with_cached_hdata(
     mock_dataset_single_sample,
 ):
@@ -473,50 +467,56 @@ def test_collate_sample_full_hypergraph_does_not_share_storage_with_cached_hdata
     batched = loader.collate([mock_dataset_single_sample[0]])
 
     cached: HData = mock_dataset_single_sample.hdata
+
     assert batched is not cached
-    # The most-likely-mutated tensors must not share storage with the
-    # cached dataset, otherwise a downstream caller mutating the batch
-    # would corrupt the dataset.
     assert batched.x.data_ptr() != cached.x.data_ptr()
     assert batched.hyperedge_index.data_ptr() != cached.hyperedge_index.data_ptr()
     assert batched.hyperedge_attr is not None
-    assert batched.hyperedge_attr.data_ptr() != cached.hyperedge_attr.data_ptr()
+    assert (
+        batched.hyperedge_attr.data_ptr()
+        != utils.to_non_empty_edgeattr(cached.hyperedge_attr).data_ptr()
+    )
+    assert batched.hyperedge_weights is not None
+    assert (
+        batched.hyperedge_weights.data_ptr()
+        != utils.to_non_empty_edgeattr(cached.hyperedge_weights).data_ptr()
+    )
 
 
 def test_collate_sample_full_hypergraph_mutating_batch_does_not_affect_cached_hdata(
     mock_dataset_single_sample,
 ):
-    cached: HData = mock_dataset_single_sample.hdata
-    cached_x_snapshot = cached.x.clone()
-    cached_hyperedge_index_snapshot = cached.hyperedge_index.clone()
-    cached_hyperedge_attr_snapshot = cached.hyperedge_attr.clone()
-
     loader = DataLoader(mock_dataset_single_sample, sample_full_hypergraph=True)
+
+    cached: HData = mock_dataset_single_sample.hdata
+    cached_x = cached.x.clone()
+    cached_hyperedge_index = cached.hyperedge_index.clone()
+    cached_hyperedge_attr = utils.to_non_empty_edgeattr(cached.hyperedge_attr).clone()
+    cached_hypeedge_weights = utils.to_non_empty_edgeattr(cached.hyperedge_weights).clone()
+
     batched = loader.collate([mock_dataset_single_sample[0]])
 
-    batched.x.add_(1.0)
-    batched.hyperedge_index.fill_(99)
-    batched.hyperedge_attr.add_(1.0)
+    batched.x = torch.zeros_like(cached_x)
+    batched.hyperedge_index = torch.zeros_like(cached_hyperedge_index)
+    batched.hyperedge_attr = torch.zeros_like(cached_hyperedge_attr)
+    batched.hyperedge_weights = torch.zeros_like(cached_hypeedge_weights)
 
-    assert torch.equal(cached.x, cached_x_snapshot)
-    assert torch.equal(cached.hyperedge_index, cached_hyperedge_index_snapshot)
-    assert torch.equal(cached.hyperedge_attr, cached_hyperedge_attr_snapshot)
+    assert torch.equal(cached.x, cached_x)
+    assert not torch.equal(cached.x, batched.x)
 
+    assert torch.equal(cached.hyperedge_index, cached_hyperedge_index)
+    assert not torch.equal(cached.hyperedge_index, batched.hyperedge_index)
 
-def test_collate_sample_full_hypergraph_with_weights_isolates_weights(
-    mock_dataset_single_sample_with_weights,
-):
-    cached: HData = mock_dataset_single_sample_with_weights.hdata
-    cached_weights_snapshot = cached.hyperedge_weights.clone()
-
-    loader = DataLoader(
-        mock_dataset_single_sample_with_weights, sample_full_hypergraph=True,
+    assert torch.equal(utils.to_non_empty_edgeattr(cached.hyperedge_attr), cached_hyperedge_attr)
+    assert not torch.equal(
+        utils.to_non_empty_edgeattr(cached.hyperedge_attr),
+        utils.to_non_empty_edgeattr(batched.hyperedge_attr),
     )
-    batched = loader.collate([mock_dataset_single_sample_with_weights[0]])
 
-    assert batched.hyperedge_weights is not None
-    assert batched.hyperedge_weights.data_ptr() != cached.hyperedge_weights.data_ptr()
-
-    batched.hyperedge_weights.fill_(0.0)
-
-    assert torch.equal(cached.hyperedge_weights, cached_weights_snapshot)
+    assert torch.equal(
+        utils.to_non_empty_edgeattr(cached.hyperedge_weights), cached_hypeedge_weights
+    )
+    assert not torch.equal(
+        utils.to_non_empty_edgeattr(cached.hyperedge_weights),
+        utils.to_non_empty_edgeattr(batched.hyperedge_weights),
+    )

--- a/hyperbench/types/hdata.py
+++ b/hyperbench/types/hdata.py
@@ -681,28 +681,28 @@ class HData:
 
     def clone(self) -> "HData":
         """
-        Return a deep copy of this :class:`HData` with independent tensor storage.
-
-        Useful when a caller wants to mutate or device-transfer a derived
-        :class:`HData` without leaking changes back into the original — see
-        e.g. :class:`hyperbench.data.DataLoader` with
-        ``sample_full_hypergraph=True``, which historically returned the
-        cached dataset object directly and was vulnerable to in-place
-        mutation by ``HData.to`` (issue #173).
+        Return a deep copy of this :class:`HData`.
 
         Returns:
-            A new :class:`HData` whose every tensor field is a fresh
-            ``.clone()`` of the original; ``num_nodes`` / ``num_hyperedges``
-            are passed through unchanged.
+            A new :class:`HData` that is a deep copy of this instance.
         """
+        cloned_hyperedge_weights = (
+            self.hyperedge_weights.clone() if self.hyperedge_weights is not None else None
+        )
+        cloned_hyperedge_attr = (
+            self.hyperedge_attr.clone() if self.hyperedge_attr is not None else None
+        )
+        cloned_global_node_ids = (
+            self.global_node_ids.clone() if self.global_node_ids is not None else None
+        )
         return self.__class__(
             x=self.x.clone(),
             hyperedge_index=self.hyperedge_index.clone(),
-            hyperedge_weights=self.hyperedge_weights.clone() if self.hyperedge_weights is not None else None,
-            hyperedge_attr=self.hyperedge_attr.clone() if self.hyperedge_attr is not None else None,
+            hyperedge_weights=cloned_hyperedge_weights,
+            hyperedge_attr=cloned_hyperedge_attr,
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
-            global_node_ids=self.global_node_ids.clone() if self.global_node_ids is not None else None,
+            global_node_ids=cloned_global_node_ids,
             y=self.y.clone(),
         )
 

--- a/hyperbench/types/hdata.py
+++ b/hyperbench/types/hdata.py
@@ -679,6 +679,33 @@ class HData:
             y=new_y,
         )
 
+    def clone(self) -> "HData":
+        """
+        Return a deep copy of this :class:`HData` with independent tensor storage.
+
+        Useful when a caller wants to mutate or device-transfer a derived
+        :class:`HData` without leaking changes back into the original — see
+        e.g. :class:`hyperbench.data.DataLoader` with
+        ``sample_full_hypergraph=True``, which historically returned the
+        cached dataset object directly and was vulnerable to in-place
+        mutation by ``HData.to`` (issue #173).
+
+        Returns:
+            A new :class:`HData` whose every tensor field is a fresh
+            ``.clone()`` of the original; ``num_nodes`` / ``num_hyperedges``
+            are passed through unchanged.
+        """
+        return self.__class__(
+            x=self.x.clone(),
+            hyperedge_index=self.hyperedge_index.clone(),
+            hyperedge_weights=self.hyperedge_weights.clone() if self.hyperedge_weights is not None else None,
+            hyperedge_attr=self.hyperedge_attr.clone() if self.hyperedge_attr is not None else None,
+            num_nodes=self.num_nodes,
+            num_hyperedges=self.num_hyperedges,
+            global_node_ids=self.global_node_ids.clone() if self.global_node_ids is not None else None,
+            y=self.y.clone(),
+        )
+
     def to(self, device: torch.device | str, non_blocking: bool = False) -> "HData":
         """
         Move all tensors to the specified device.


### PR DESCRIPTION
### All Submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Description

Closes #173.

`DataLoader.collate()` returned `self.__cached_dataset_hdata.to(batch[0].device)` when `sample_full_hypergraph=True`. Because `HData.to()` is in-place, this returned the cached dataset object itself. As a result, iterating the dataloader and mutating the batch, or transferring through a different device path on the next iteration, could silently mutate the dataset's cached `hdata`.

This change introduces a public `HData.clone()` method that returns a structurally independent `HData`: tensor fields are cloned, while scalar fields are passed through. The loader now uses `clone().to(...)` instead of calling `to(...)` directly on the cached object.

The clone happens once per batch in the sample-full path, so the cost is bounded by dataset size and is the same order of magnitude as the device transfer already performed there.

Test plan:

Three regression tests were added in `hyperbench/tests/data/loader_test.py`:

- `test_collate_sample_full_hypergraph_does_not_share_storage_with_cached_hdata`
  — checks `data_ptr` inequality across `x`, `hyperedge_index`, and `hyperedge_attr`.
- `test_collate_sample_full_hypergraph_mutating_batch_does_not_affect_cached_hdata`
  — mutates the batch in place and confirms the cached `hdata` tensors are unchanged.
- `test_collate_sample_full_hypergraph_with_weights_isolates_weights`
  — verifies the same isolation for `hyperedge_weights`.

Each test fails when only `loader.py` and `hdata.py` are reverted, confirming they exercise the new behavior. The existing `test_collate_sample_full_hypergraph_returns_cached_hdata` content-equality test continues to pass.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make lint`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
- [x] Have you added an explanation of what your changes are and why you'd like us to include them?