### PR TITLE
Export dependency modules from hyperbench

### DIFF
--- a/hyperbench/__init__.py
+++ b/hyperbench/__init__.py
@@ -1,3 +1,4 @@
+import importlib
 import warnings
 
 
@@ -7,3 +8,13 @@ warnings.filterwarnings("ignore", message=".*isinstance.*LeafSpec.*is deprecated
 
 warnings.filterwarnings("ignore", message="Sparse CSR tensor support is in beta state")
 warnings.filterwarnings("ignore", message="Sparse invariant checks are implicitly disabled")
+
+__all__ = ["lightning", "torch_geometric", "torchmetrics"]
+
+
+def __getattr__(name):
+    if name in __all__:
+        module = importlib.import_module(name)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/hyperbench/tests/dependency_exports_test.py
+++ b/hyperbench/tests/dependency_exports_test.py
@@ -1,0 +1,15 @@
+import sys
+import types
+
+import pytest
+
+import hyperbench
+
+
+@pytest.mark.parametrize("name", ["lightning", "torch_geometric", "torchmetrics"])
+def test_dependency_modules_are_exported(monkeypatch, name):
+    module = types.ModuleType(name)
+    monkeypatch.setitem(sys.modules, name, module)
+    hyperbench.__dict__.pop(name, None)
+
+    assert getattr(hyperbench, name) is module


### PR DESCRIPTION
This exposes the external dependency modules through the top-level `hyperbench` package so users can access them as `hyperbench.lightning`, `hyperbench.torch_geometric`, and `hyperbench.torchmetrics` without importing those packages directly. The exports are loaded lazily to keep `import hyperbench` lightweight, and a small test covers each exported module name.
