### PR TITLE
Add timeout=10 to get_gh_dataset_sha request

### DIFF
--- a/hyperbench/tests/utils/hif_utils_test.py
+++ b/hyperbench/tests/utils/hif_utils_test.py
@@ -196,12 +196,10 @@ def test_get_gh_datasets_shas_returns_shas_and_none_on_failure():
     }
     mock_requests_get.assert_any_call(
         "https://api.github.com/repos/hypernetwork-research-group/datasets/commits",
-        params={"path": "algebra.json.zst", "per_page": 1},
-    )
+        params={"path": "algebra.json.zst", "per_page": 1}, timeout=10,)
     mock_requests_get.assert_any_call(
         "https://api.github.com/repos/hypernetwork-research-group/datasets/commits",
-        params={"path": "missing-dataset.json.zst", "per_page": 1},
-    )
+        params={"path": "missing-dataset.json.zst", "per_page": 1}, timeout=10,)
 
 
 def test_get_gh_dataset_trigger_no_commit():
@@ -221,5 +219,4 @@ def test_get_gh_dataset_trigger_no_commit():
     assert result is None
     mock_requests_get.assert_called_once_with(
         "https://api.github.com/repos/owner/repo/commits",
-        params={"path": "algebra.json.zst", "per_page": 1},
-    )
+        params={"path": "algebra.json.zst", "per_page": 1}, timeout=10,)

--- a/hyperbench/utils/hif_utils.py
+++ b/hyperbench/utils/hif_utils.py
@@ -84,7 +84,7 @@ def get_gh_dataset_sha(dataset_name: str, owner: str, repository: str) -> str | 
     }
 
     try:
-        response = requests.get(url, params=params)
+        response = requests.get(url, params=params, timeout=10)
         response.raise_for_status()
     except requests.RequestException as e:
         warnings.warn(


### PR DESCRIPTION
## Summary

Adds `timeout=10` to the `requests.get()` call in `get_gh_dataset_sha()` (hyperbench/utils/hif_utils.py:87), matching the pattern used for all other requests in the codebase.

Without a timeout, this request could hang indefinitely if GitHub's API is slow or unresponsive.

Fixes #200