### PR TITLE
Add named docstring outputs

### DIFF
--- a/hyperbench/data/dataset.py
+++ b/hyperbench/data/dataset.py
@@ -61,7 +61,7 @@ class Dataset(TorchDataset):
             index: An integer or a list of integers representing node or hyperedge IDs to sample, depending on the sampling strategy.
 
         Returns:
-            An HData instance containing the sampled sub-hypergraph.
+            hdata: An HData instance containing the sampled sub-hypergraph.
 
         Raises:
             ValueError: If the provided index is invalid (e.g., empty list or list length exceeds number of nodes/hyperedges).
@@ -83,7 +83,7 @@ class Dataset(TorchDataset):
             sampling_strategy: The sampling strategy to use for the dataset. If not provided, defaults to ``SamplingStrategy.HYPEREDGE``.
 
         Returns:
-            The :class:`Dataset` instance with the provided :class:`HData`.
+            dataset: The :class:`Dataset` instance with the provided :class:`HData`.
         """
         return cls(hdata=hdata, sampling_strategy=sampling_strategy)
 
@@ -103,7 +103,7 @@ class Dataset(TorchDataset):
             save_on_disk: Whether to save the downloaded file on disk.
 
         Returns:
-            The :class:`Dataset` instance with the loaded hypergraph data.
+            dataset: The :class:`Dataset` instance with the loaded hypergraph data.
         """
         hdata = HIFLoader.load_from_url(url=url, save_on_disk=save_on_disk)
         dataset = cls.from_hdata(hdata=hdata, sampling_strategy=sampling_strategy)
@@ -123,7 +123,7 @@ class Dataset(TorchDataset):
             sampling_strategy: The sampling strategy to use for the dataset. If not provided, defaults to ``SamplingStrategy.HYPEREDGE``.
 
         Returns:
-            The :class:`Dataset` instance with the loaded hypergraph data.
+            dataset: The :class:`Dataset` instance with the loaded hypergraph data.
         """
         hypergraph = HIFLoader.load_from_path(filepath=filepath)
         dataset = cls.from_hdata(hdata=hypergraph, sampling_strategy=sampling_strategy)
@@ -219,7 +219,7 @@ class Dataset(TorchDataset):
             hdata: :class:`HData` object containing the hypergraph data.
 
         Returns:
-            The :class:`Dataset` instance with the provided :class:`HData`.
+            dataset: The :class:`Dataset` instance with the provided :class:`HData`.
         """
         return self.__class__(hdata=hdata, sampling_strategy=self.sampling_strategy)
 
@@ -236,7 +236,7 @@ class Dataset(TorchDataset):
             seed: Optional random seed used for both negative sampling and the final shuffle.
 
         Returns:
-            A new :class:`Dataset` instance with positives and sampled negatives.
+            dataset: A new :class:`Dataset` instance with positives and sampled negatives.
         """
         hdata_with_negatives = self.hdata.clone()
         hdata_with_negatives = hdata_with_negatives.add_negative_samples(
@@ -304,7 +304,7 @@ class Dataset(TorchDataset):
                 ``first`` preserves only the first returned split. ``all`` preserves all splits.
 
         Returns:
-            List of Dataset objects, one per split, each with contiguous IDs.
+            datasets: List of Dataset objects, one per split, each with contiguous IDs.
         """
         # Allow small imprecision in sum of ratios, but raise error if it's significant
         # Example: ratios = [0.8, 0.1, 0.1] -> sum = 1.0 (valid)
@@ -380,7 +380,7 @@ class Dataset(TorchDataset):
             device: The target device (e.g., ``torch.device('cuda')`` or ``torch.device('cpu')``).
 
         Returns:
-            The Dataset instance moved to the specified device.
+            dataset: The Dataset instance moved to the specified device.
         """
         self.hdata = self.hdata.to(device)
         return self
@@ -422,7 +422,7 @@ class Dataset(TorchDataset):
         - ``distribution_hyperedge_size_hist``: A dictionary where the keys are hyperedge sizes and the values are the count of hyperedges with that size.
 
         Returns:
-            A dictionary containing various statistics about the hypergraph.
+            stats: A dictionary containing various statistics about the hypergraph.
         """
 
         return self.hdata.stats()

--- a/hyperbench/data/dataset.py
+++ b/hyperbench/data/dataset.py
@@ -76,14 +76,14 @@ class Dataset(TorchDataset):
         sampling_strategy: SamplingStrategy = SamplingStrategy.HYPEREDGE,
     ) -> "Dataset":
         """
-        Create a :class:`Dataset` instance from an :class:`HData` object.
+        Create a `Dataset` instance from an `HData` object.
 
         Args:
-            hdata: :class:`HData` object containing the hypergraph data.
+            hdata: `HData` object containing the hypergraph data.
             sampling_strategy: The sampling strategy to use for the dataset. If not provided, defaults to ``SamplingStrategy.HYPEREDGE``.
 
         Returns:
-            dataset: The :class:`Dataset` instance with the provided :class:`HData`.
+            dataset: The `Dataset` instance with the provided `HData`.
         """
         return cls(hdata=hdata, sampling_strategy=sampling_strategy)
 
@@ -95,7 +95,7 @@ class Dataset(TorchDataset):
         save_on_disk: bool = False,
     ) -> "Dataset":
         """
-        Create a :class:`Dataset` instance by loading a hypergraph from a URL pointing to a .json or .json.zst file in HIF format.
+        Create a `Dataset` instance by loading a hypergraph from a URL pointing to a .json or .json.zst file in HIF format.
 
         Args:
             url: The URL to the .json or .json.zst file containing the HIF hypergraph data.
@@ -103,7 +103,7 @@ class Dataset(TorchDataset):
             save_on_disk: Whether to save the downloaded file on disk.
 
         Returns:
-            dataset: The :class:`Dataset` instance with the loaded hypergraph data.
+            dataset: The `Dataset` instance with the loaded hypergraph data.
         """
         hdata = HIFLoader.load_from_url(url=url, save_on_disk=save_on_disk)
         dataset = cls.from_hdata(hdata=hdata, sampling_strategy=sampling_strategy)
@@ -116,14 +116,14 @@ class Dataset(TorchDataset):
         sampling_strategy: SamplingStrategy = SamplingStrategy.HYPEREDGE,
     ) -> "Dataset":
         """
-        Create a :class:`Dataset` instance by loading a hypergraph from a local file path pointing to a .json or .json.zst file in HIF format.
+        Create a `Dataset` instance by loading a hypergraph from a local file path pointing to a .json or .json.zst file in HIF format.
 
         Args:
             filepath: The local file path to the .json or .json.zst file containing the HIF hypergraph data.
             sampling_strategy: The sampling strategy to use for the dataset. If not provided, defaults to ``SamplingStrategy.HYPEREDGE``.
 
         Returns:
-            dataset: The :class:`Dataset` instance with the loaded hypergraph data.
+            dataset: The `Dataset` instance with the loaded hypergraph data.
         """
         hypergraph = HIFLoader.load_from_path(filepath=filepath)
         dataset = cls.from_hdata(hdata=hypergraph, sampling_strategy=sampling_strategy)
@@ -213,13 +213,13 @@ class Dataset(TorchDataset):
 
     def update_from_hdata(self, hdata: HData) -> "Dataset":
         """
-        Create a :class:`Dataset` instance from an :class:`HData` object.
+        Create a `Dataset` instance from an `HData` object.
 
         Args:
-            hdata: :class:`HData` object containing the hypergraph data.
+            hdata: `HData` object containing the hypergraph data.
 
         Returns:
-            dataset: The :class:`Dataset` instance with the provided :class:`HData`.
+            dataset: The `Dataset` instance with the provided `HData`.
         """
         return self.__class__(hdata=hdata, sampling_strategy=self.sampling_strategy)
 
@@ -229,14 +229,14 @@ class Dataset(TorchDataset):
         seed: int | None = None,
     ) -> "Dataset":
         """
-        Create a new :class:`Dataset` with sampled negative hyperedges added.
+        Create a new `Dataset` with sampled negative hyperedges added.
 
         Args:
             negative_sampler: Sampler used to generate negative hyperedges from this dataset's ``hdata``.
             seed: Optional random seed used for both negative sampling and the final shuffle.
 
         Returns:
-            dataset: A new :class:`Dataset` instance with positives and sampled negatives.
+            dataset: A new `Dataset` instance with positives and sampled negatives.
         """
         hdata_with_negatives = self.hdata.clone()
         hdata_with_negatives = hdata_with_negatives.add_negative_samples(

--- a/hyperbench/data/hif.py
+++ b/hyperbench/data/hif.py
@@ -23,7 +23,7 @@ GITHUB_COMMIT_SHA = "3879b2ce84750e54f984ca06ce3246dff22c71c7"
 
 
 class HIFProcessor:
-    """A utility class to process HIF hypergraph data into :class:`HData` format."""
+    """A utility class to process HIF hypergraph data into `HData` format."""
 
     @staticmethod
     def transform_attrs(
@@ -60,7 +60,7 @@ class HIFProcessor:
     @classmethod
     def process_hypergraph(cls, hypergraph: HIFHypergraph) -> HData:
         """
-        Process the loaded hypergraph into :class:`HData` format, mapping HIF structure to tensors.
+        Process the loaded hypergraph into `HData` format, mapping HIF structure to tensors.
 
         Returns:
             hdata: The processed hypergraph data.

--- a/hyperbench/data/hif.py
+++ b/hyperbench/data/hif.py
@@ -39,7 +39,7 @@ class HIFProcessor:
             attr_keys: Optional list of attribute keys to encode. If provided, ensures consistent ordering and fill missing with ``0.0``.
 
         Returns:
-            Tensor of numeric attribute values
+            attrs: Tensor of numeric attribute values
         """
         numeric_attrs = {
             key: value
@@ -63,7 +63,7 @@ class HIFProcessor:
         Process the loaded hypergraph into :class:`HData` format, mapping HIF structure to tensors.
 
         Returns:
-            The processed hypergraph data.
+            hdata: The processed hypergraph data.
         """
 
         num_nodes = len(hypergraph.nodes)
@@ -132,7 +132,7 @@ class HIFProcessor:
             attr_keys: List of attribute dictionaries.
 
         Returns:
-            List of unique numeric attribute keys.
+            attr_keys: List of unique numeric attribute keys.
         """
         unique_keys = []
         for attrs in attr_keys:
@@ -245,7 +245,7 @@ class HIFLoader:
             url (str): The URL to the .json or .json.zst file containing the HIF hypergraph data.
             save_on_disk (bool): Whether to save the downloaded file on disk.
         Returns:
-            HData: The loaded hypergraph object.
+            hdata: The loaded hypergraph object.
         """
         url = validate_http_url(url)
 
@@ -286,7 +286,7 @@ class HIFLoader:
             filepath (str): The local file path to the .json or .json.zst file
                 containing the HIF hypergraph data.
         Returns:
-            HData: The loaded hypergraph object.
+            hdata: The loaded hypergraph object.
         """
         if not os.path.exists(filepath):
             raise ValueError(f"File '{filepath}' does not exist.")

--- a/hyperbench/data/loader.py
+++ b/hyperbench/data/loader.py
@@ -28,7 +28,7 @@ class DataLoader(TorchDataLoader):
 
     def collate(self, batch: list[HData]) -> HData:
         """
-        Collates a list of :class:`HData objects into a single batched :class:`HData object.
+        Collates a list of `HData objects into a single batched `HData object.
 
         This function combines multiple separate samples into a single batched representation suitable for mini-batch training.
         It handles:
@@ -64,10 +64,10 @@ class DataLoader(TorchDataLoader):
             ...                    [0, 0, 1, 1, 2, 2]]  # Hyperedge IDs: original then offset by 2
 
         Args:
-            batch: List of :class:`HData objects to collate.
+            batch: List of `HData objects to collate.
 
         Returns:
-            hdata: A single :class:`HData` object containing the collated data.
+            hdata: A single `HData` object containing the collated data.
         """
         if self.__sample_full_hypergraph:
             return self.__cached_dataset_hdata.clone().to(batch[0].device)

--- a/hyperbench/data/loader.py
+++ b/hyperbench/data/loader.py
@@ -67,7 +67,7 @@ class DataLoader(TorchDataLoader):
             batch: List of :class:`HData objects to collate.
 
         Returns:
-            A single :class:`HData` object containing the collated data.
+            hdata: A single :class:`HData` object containing the collated data.
         """
         if self.__sample_full_hypergraph:
             return self.__cached_dataset_hdata.clone().to(batch[0].device)

--- a/hyperbench/data/sampling.py
+++ b/hyperbench/data/sampling.py
@@ -22,7 +22,7 @@ class BaseSampler(ABC):
             hdata: The original HData to sample from.
 
         Returns:
-            A new HData instance containing only the sampled items and their associated data.
+            hdata: A new HData instance containing only the sampled items and their associated data.
         """
         raise NotImplementedError("Subclasses must implement the sample method.")
 
@@ -45,7 +45,7 @@ class BaseSampler(ABC):
             size: The total number of sampleable items (e.g., nodes or hyperedges) for validation.
 
         Returns:
-            List of IDs to sample.
+            ids: List of IDs to sample.
 
         Raises:
             ValueError: If the provided index is invalid (e.g., empty list or list length exceeds number of sampleable items).
@@ -73,7 +73,7 @@ class BaseSampler(ABC):
             sampled_hyperedge_ids: A tensor containing the IDs of hyperedges to sample.
 
         Returns:
-            A new hyperedge index tensor containing only the incidences of the sampled hyperedges.
+            hyperedge_index: A new hyperedge index tensor containing only the incidences of the sampled hyperedges.
         """
         hyperedge_ids = hyperedge_index[1]
 
@@ -128,7 +128,7 @@ class HyperedgeSampler(BaseSampler):
             hdata: The original HData to sample from.
 
         Returns:
-            An HData instance containing only the sampled hyperedges and their incident nodes.
+            hdata: An HData instance containing only the sampled hyperedges and their incident nodes.
 
         Raises:
             ValueError: If the provided index is invalid (e.g., empty list or list length exceeds number of hyperedges).
@@ -161,7 +161,7 @@ class HyperedgeSampler(BaseSampler):
             hdata: The HData to query for the number of hyperedges.
 
         Returns:
-            The number of hyperedges in the HData.
+            num_hyperedges: The number of hyperedges in the HData.
         """
         return hdata.num_hyperedges
 
@@ -186,7 +186,7 @@ class NodeSampler(BaseSampler):
             hdata: The original HData to sample from.
 
         Returns:
-            An HData instance containing only the sampled nodes and their incident hyperedges.
+            hdata: An HData instance containing only the sampled nodes and their incident hyperedges.
 
         Raises:
             ValueError: If the provided index is invalid (e.g., empty list or list length exceeds number of nodes).
@@ -231,7 +231,7 @@ class NodeSampler(BaseSampler):
             hdata: The HData to query for the number of nodes.
 
         Returns:
-            The number of nodes in the HData.
+            num_nodes: The number of nodes in the HData.
         """
         return hdata.num_nodes
 
@@ -244,7 +244,7 @@ def create_sampler_from_strategy(strategy: SamplingStrategy) -> BaseSampler:
         strategy: An instance of SamplingStrategy enum indicating which sampling strategy to use.
 
     Returns:
-        An instance of a subclass of BaseSampler corresponding to the specified strategy. If strategy is not recognized, defaults to ``HyperedgeSampler``.
+        sampler: An instance of a subclass of BaseSampler corresponding to the specified strategy. If strategy is not recognized, defaults to ``HyperedgeSampler``.
     """
     match strategy:
         case SamplingStrategy.NODE:

--- a/hyperbench/hlp/common.py
+++ b/hyperbench/hlp/common.py
@@ -79,7 +79,7 @@ class HlpModule(L.LightningModule):
             stage: The current stage (train/val/test) for logging purposes.
 
         Returns:
-            The computed loss tensor.
+            loss: The computed loss tensor.
         """
         loss = self.loss_fn(scores, labels)
         self.log(name=f"{stage.value}_loss", value=loss, prog_bar=True, batch_size=batch_size)
@@ -133,7 +133,7 @@ class HlpModule(L.LightningModule):
             stage: The current stage (train/val/test) for which to get metrics.
 
         Returns:
-            The metric collection corresponding to the given stage, or ``None`` if no metrics are configured.
+            metrics: The metric collection corresponding to the given stage, or ``None`` if no metrics are configured.
         """
         match stage:
             case Stage.TRAIN:
@@ -161,7 +161,7 @@ class HlpModule(L.LightningModule):
             batch: The current batch of data for which to sample negatives.
 
         Returns:
-            A batch of negative samples, either freshly sampled or from cache.
+            negatives: A batch of negative samples, either freshly sampled or from cache.
         """
         if self.__negative_sampling_scheduler is None:
             raise ValueError("Asked to sample negatives but no negative sampler is not configured.")

--- a/hyperbench/hlp/common_neighbors_hlp.py
+++ b/hyperbench/hlp/common_neighbors_hlp.py
@@ -89,7 +89,7 @@ class CommonNeighborsHlpModule(HlpModule):
             stage: The current stage of evaluation (e.g., ``Stage.TRAIN``, ``Stage.VAL``, ``Stage.TEST``).
 
         Returns:
-            The computed loss.
+            loss: The computed loss.
         """
         scores = self.forward(batch.hyperedge_index)
         labels = batch.y

--- a/hyperbench/hlp/common_neighbors_hlp.py
+++ b/hyperbench/hlp/common_neighbors_hlp.py
@@ -17,7 +17,7 @@ class CommonNeighborsHlpModule(HlpModule):
 
     Args:
         aggregation: The aggregation method for common neighbors ("mean", "min", or "sum").
-        decoder: An optional decoder module. Defaults to :class:`CommonNeighbors`.
+        decoder: An optional decoder module. Defaults to `CommonNeighbors`.
         loss_fn: An optional loss function. Defaults to ``BCEWithLogitsLoss``.
         metrics: An optional dictionary of metric functions.
     """
@@ -85,7 +85,7 @@ class CommonNeighborsHlpModule(HlpModule):
         Shared evaluation logic for all stages.
 
         Args:
-            batch: :class:`HData` object containing the hypergraph.
+            batch: `HData` object containing the hypergraph.
             stage: The current stage of evaluation (e.g., ``Stage.TRAIN``, ``Stage.VAL``, ``Stage.TEST``).
 
         Returns:

--- a/hyperbench/hlp/gcn_hlp.py
+++ b/hyperbench/hlp/gcn_hlp.py
@@ -107,7 +107,7 @@ class GCNHlpModule(HlpModule):
             hyperedge_index: Hyperedge connectivity of shape ``(2, num_incidences)``.
 
         Returns:
-            Logit scores of shape ``(num_hyperedges,)``.
+            scores: Logit scores of shape ``(num_hyperedges,)``.
         """
         if self.encoder is None:
             raise ValueError("Encoder is not defined for this HLP module.")

--- a/hyperbench/hlp/hgnn_hlp.py
+++ b/hyperbench/hlp/hgnn_hlp.py
@@ -118,7 +118,7 @@ class HGNNHlpModule(HlpModule):
                 with row 0 containing global node IDs and row 1 hyperedge IDs.
 
         Returns:
-            Logit scores of shape ``(num_hyperedges,)``. Pass through sigmoid to get
+            scores: Logit scores of shape ``(num_hyperedges,)``. Pass through sigmoid to get
             probabilities, or use directly with ``BCEWithLogitsLoss``.
         """
         if self.encoder is None:

--- a/hyperbench/hlp/hgnnp_hlp.py
+++ b/hyperbench/hlp/hgnnp_hlp.py
@@ -100,7 +100,7 @@ class HGNNPHlpModule(HlpModule):
                 with row 0 containing global node IDs and row 1 hyperedge IDs.
 
         Returns:
-            Logit scores of shape ``(num_hyperedges,)``.
+            scores: Logit scores of shape ``(num_hyperedges,)``.
         """
         if self.encoder is None:
             raise ValueError("Encoder is not defined for this HLP module.")

--- a/hyperbench/hlp/hnhn_hlp.py
+++ b/hyperbench/hlp/hnhn_hlp.py
@@ -93,7 +93,7 @@ class HNHNHlpModule(HlpModule):
             hyperedge_index: Hyperedge connectivity of shape ``(2, num_incidences)``.
 
         Returns:
-            Logit scores of shape ``(num_hyperedges,)``.
+            scores: Logit scores of shape ``(num_hyperedges,)``.
         """
         if self.encoder is None:
             raise ValueError("Encoder is not defined for this HLP module.")

--- a/hyperbench/hlp/hypergcn_hlp.py
+++ b/hyperbench/hlp/hypergcn_hlp.py
@@ -117,7 +117,7 @@ class HyperGCNHlpModule(HlpModule):
                 with **global** node IDs.
 
         Returns:
-            Scores of shape ``(num_hyperedges,)``.
+            scores: Scores of shape ``(num_hyperedges,)``.
         """
         if self.encoder is None:
             raise ValueError("Encoder is not defined for this HLP module.")

--- a/hyperbench/hlp/mlp_hlp.py
+++ b/hyperbench/hlp/mlp_hlp.py
@@ -121,7 +121,7 @@ class MLPHlpModule(HlpModule):
             hyperedge_index: Hyperedge connectivity of shape ``(2, num_incidences)``.
 
         Returns:
-            Scores of shape ``(num_hyperedges,)``.
+            scores: Scores of shape ``(num_hyperedges,)``.
         """
         if self.encoder is None:
             raise ValueError("Encoder is not defined for this HLP module.")

--- a/hyperbench/hlp/nhp_hlp.py
+++ b/hyperbench/hlp/nhp_hlp.py
@@ -40,7 +40,7 @@ class NHPHlpModule(HlpModule):
 
     Args:
         encoder_config: Configuration for the NHP encoder/scorer.
-        loss_fn: Loss function. Defaults to :class:`NHPRankingLoss`.
+        loss_fn: Loss function. Defaults to `NHPRankingLoss`.
         lr: Learning rate for the optimizer. Defaults to ``0.001``.
         weight_decay: L2 regularization. Defaults to ``5e-4``.
         metrics: Optional metric collection for evaluation.

--- a/hyperbench/hlp/nhp_hlp.py
+++ b/hyperbench/hlp/nhp_hlp.py
@@ -82,7 +82,7 @@ class NHPHlpModule(HlpModule):
             hyperedge_index: Hyperedge connectivity of shape ``(2, num_incidences)``.
 
         Returns:
-            Scores of shape ``(num_hyperedges,)``.
+            scores: Scores of shape ``(num_hyperedges,)``.
         """
         if self.encoder is None:
             raise ValueError("Encoder is not defined for this HLP module.")

--- a/hyperbench/models/common_neighbors.py
+++ b/hyperbench/models/common_neighbors.py
@@ -28,7 +28,7 @@ class CommonNeighbors(nn.Module):
             node_to_neighbors: Optional mapping from nodes to their neighborhoods.
 
         Returns:
-            A 1-D tensor of shape (num_hyperedges,) with CN scores.
+            scores: A 1-D tensor of shape (num_hyperedges,) with CN scores.
         """
         scores = self.scorer.score_batch(hyperedge_index, node_to_neighbors)
         torch.log1p(scores, out=scores)

--- a/hyperbench/models/hgnn.py
+++ b/hyperbench/models/hgnn.py
@@ -65,7 +65,7 @@ class HGNN(nn.Module):
                 where row 0 contains node IDs and row 1 contains hyperedge IDs.
 
         Returns:
-            The output node feature matrix. Size ``(num_nodes, num_classes)``.
+            x: The output node feature matrix. Size ``(num_nodes, num_classes)``.
         """
         for layer in self.layers:
             x = layer(x, hyperedge_index)

--- a/hyperbench/models/hgnnp.py
+++ b/hyperbench/models/hgnnp.py
@@ -58,7 +58,7 @@ class HGNNP(nn.Module):
                 where row 0 contains node IDs and row 1 contains hyperedge IDs.
 
         Returns:
-            The output node feature matrix. Size ``(num_nodes, num_classes)``.
+            x: The output node feature matrix. Size ``(num_nodes, num_classes)``.
         """
         for layer in self.layers:
             x = layer(x, hyperedge_index)

--- a/hyperbench/models/hnhn.py
+++ b/hyperbench/models/hnhn.py
@@ -58,7 +58,7 @@ class HNHN(nn.Module):
             hyperedge_index: Hyperedge incidence in COO format of size ``(2, num_incidences)``.
 
         Returns:
-            The output node feature matrix of size ``(num_nodes, num_classes)``.
+            x: The output node feature matrix of size ``(num_nodes, num_classes)``.
         """
         for layer in self.layers:
             x = layer(x, hyperedge_index)

--- a/hyperbench/models/hypergcn.py
+++ b/hyperbench/models/hypergcn.py
@@ -68,7 +68,7 @@ class HyperGCN(nn.Module):
             hyperedge_index: The hyperedge indices of the hypergraph. Size ``(2, num_hyperedges)``.
 
         Returns:
-            The output node feature matrix. Size ``(num_nodes, num_classes)``.
+            x: The output node feature matrix. Size ``(num_nodes, num_classes)``.
         """
         if not self.fast:
             for layer in self.layers:

--- a/hyperbench/models/nhp.py
+++ b/hyperbench/models/nhp.py
@@ -76,7 +76,7 @@ class NHP(nn.Module):
             hyperedge_index: Incidence tensor of shape ``(2, num_incidences)``.
 
         Returns:
-            Scores of shape ``(num_hyperedges,)``.
+            scores: Scores of shape ``(num_hyperedges,)``.
         """
         if hyperedge_index.numel() == 0:
             return x.new_empty((0,))

--- a/hyperbench/models/villain.py
+++ b/hyperbench/models/villain.py
@@ -91,7 +91,7 @@ class VilLain(nn.Module):
                 If not provided, the hyperedge count is inferred from ``hyperedge_index``.
 
         Returns:
-            Node embeddings of shape ``(num_local_nodes, embedding_dim)``.
+            node_embeddings: Node embeddings of shape ``(num_local_nodes, embedding_dim)``.
         """
         return self.loss(
             hyperedge_index=hyperedge_index,
@@ -117,7 +117,7 @@ class VilLain(nn.Module):
                 If not provided, the hyperedge count is inferred from ``hyperedge_index``.
 
         Returns:
-            A tuple ``(total_loss, loss_parts)`` where ``loss_parts`` contains ``local_loss`` and ``global_loss`` scalar tensors.
+            loss: A tuple ``(total_loss, loss_parts)`` where ``loss_parts`` contains ``local_loss`` and ``global_loss`` scalar tensors.
         """
         node_embeddings = self.__get_initial_virtual_node_features(node_ids=node_ids)
         actual_num_hyperedges = self.__num_hyperedges(hyperedge_index, num_hyperedges)
@@ -159,7 +159,7 @@ class VilLain(nn.Module):
                 If not provided, the hyperedge count is inferred from ``hyperedge_index``.
 
         Returns:
-            Hyperedge embeddings of shape ``(num_hyperedges, embedding_dim)``.
+            hyperedge_embeddings: Hyperedge embeddings of shape ``(num_hyperedges, embedding_dim)``.
         """
         return self.__embeddings(
             hyperedge_index=hyperedge_index,
@@ -186,7 +186,7 @@ class VilLain(nn.Module):
                 If not provided, the hyperedge count is inferred from ``hyperedge_index``.
 
         Returns:
-            Node embeddings of shape ``(num_local_nodes, embedding_dim)``.
+            node_embeddings: Node embeddings of shape ``(num_local_nodes, embedding_dim)``.
         """
         return self.__embeddings(
             hyperedge_index=hyperedge_index,
@@ -216,7 +216,7 @@ class VilLain(nn.Module):
             mode: Selects whether to accumulate propagated node states or hyperedge states.
 
         Returns:
-            Averaged embeddings truncated to ``embedding_dim``.
+            embeddings: Averaged embeddings truncated to ``embedding_dim``.
         """
         with torch.no_grad():
             x = self.__get_initial_virtual_node_features(node_ids=node_ids)
@@ -257,7 +257,7 @@ class VilLain(nn.Module):
                 If ``None``, all node rows are used.
 
         Returns:
-            A tensor of shape ``(num_selected_nodes, raw_embedding_dim)``.
+            x: A tensor of shape ``(num_selected_nodes, raw_embedding_dim)``.
         """
         logits = self.node_embedding if node_ids is None else self.node_embedding[node_ids]
 
@@ -298,7 +298,7 @@ class VilLain(nn.Module):
             num_hyperedges: Total number of hyperedges.
 
         Returns:
-            The updated node and hyperedge embeddings after one round of message passing.
+            embeddings: The updated node and hyperedge embeddings after one round of message passing.
         """
         hyperedge_embeddings = HyperedgeAggregator(
             hyperedge_index=hyperedge_index,

--- a/hyperbench/nn/aggregator.py
+++ b/hyperbench/nn/aggregator.py
@@ -63,7 +63,7 @@ class HyperedgeAggregator:
             aggregation: Reduction applied across the nodes belonging to each hyperedge.
 
         Returns:
-            A hyperedge embedding matrix of shape ``(num_hyperedges, num_channels)``.
+            hyperedge_embeddings: A hyperedge embedding matrix of shape ``(num_hyperedges, num_channels)``.
         """
         # Gather the embeddings for each incidence.
         # A node appearing in multiple hyperedges is repeated, once per incidence.
@@ -165,7 +165,7 @@ class NodeAggregator:
             aggregation: Reduction applied across the hyperedges incident to each node.
 
         Returns:
-            A node embedding matrix of shape ``(num_nodes, num_channels)``.
+            node_embeddings: A node embedding matrix of shape ``(num_nodes, num_channels)``.
         """
         # Gather the embeddings for each incidence.
         # A hyperedge appearing in multiple node incidences is repeated, once per incidence.

--- a/hyperbench/nn/common.py
+++ b/hyperbench/nn/common.py
@@ -62,7 +62,7 @@ class _VilLainTrainer:
             hyperedge_index: Hyperedge index used only to select the output device.
 
         Returns:
-            Empty tensor of shape ``(0, embedding_dim)``.
+            x: Empty tensor of shape ``(0, embedding_dim)``.
         """
         return torch.empty((0, self.embedding_dim), device=hyperedge_index.device)
 
@@ -74,7 +74,7 @@ class _VilLainTrainer:
             hyperedge_index: Hyperedge index tensor used to infer the hyperedge count when no explicit count was provided.
 
         Returns:
-            Total number of hyperedges to preserve during VilLain propagation.
+            num_hyperedges: Total number of hyperedges to preserve during VilLain propagation.
         """
         return (
             self.num_hyperedges
@@ -90,7 +90,7 @@ class _VilLainTrainer:
             hyperedge_index: Hyperedge index tensor used to infer the node count when no explicit count was provided.
 
         Returns:
-            Total number of nodes to preserve during VilLain training and embedding generation.
+            num_nodes: Total number of nodes to preserve during VilLain training and embedding generation.
         """
         return HyperedgeIndex(hyperedge_index).num_nodes_if_isolated_exist(self.num_nodes)
 
@@ -102,7 +102,7 @@ class _VilLainTrainer:
             hyperedge_index: Hyperedge index tensor of shape ``(2, num_incidences)``.
 
         Returns:
-            Trained VilLain model ready to generate node or hyperedge embeddings.
+            model: Trained VilLain model ready to generate node or hyperedge embeddings.
         """
         # We need it here to avoid circular imports,
         # this is internal logic anyway and not part of the public API of this module.

--- a/hyperbench/nn/conv.py
+++ b/hyperbench/nn/conv.py
@@ -56,7 +56,7 @@ class HyperGCNConv(nn.Module):
                 If provided, it will be used directly for smoothing, so we can skip computing it from edge_index.
 
         Returns:
-            The output node feature matrix. Size ``(num_nodes, out_channels)``.
+            x: The output node feature matrix. Size ``(num_nodes, out_channels)``.
         """
         x = self.theta(x)
 
@@ -141,7 +141,7 @@ class HGNNConv(nn.Module):
             hyperedge_index: Hyperedge incidence in COO format of size ``(2, num_incidences)``.
 
         Returns:
-            The output node feature matrix of size ``(num_nodes, out_channels)``.
+            x: The output node feature matrix of size ``(num_nodes, out_channels)``.
         """
         x = self.theta(x)
 
@@ -208,7 +208,7 @@ class HGNNPConv(nn.Module):
             hyperedge_index: Hyperedge incidence in COO format of size ``(2, num_incidences)``.
 
         Returns:
-            The output node feature matrix of size ``(num_nodes, out_channels)``.
+            x: The output node feature matrix of size ``(num_nodes, out_channels)``.
         """
         x = self.theta(x)
 
@@ -269,7 +269,7 @@ class HNHNConv(nn.Module):
             hyperedge_index: Hyperedge incidence in COO format of size ``(2, num_incidences)``.
 
         Returns:
-            The output node feature matrix of size ``(num_nodes, out_channels)``.
+            x: The output node feature matrix of size ``(num_nodes, out_channels)``.
         """
         x = self.theta_v2e(x)
 

--- a/hyperbench/nn/enricher.py
+++ b/hyperbench/nn/enricher.py
@@ -78,7 +78,7 @@ class FillValueHyperedgeAttrsEnricher(HyperedgeAttrsEnricher):
             hyperedge_index: Hyperedge index tensor of shape ``(2, num_hyperedges)``.
 
         Returns:
-            Tensor of shape ``(num_hyperedges, 1)`` containing the generated attribute for each hyperedge.
+            hyperedge_attr: Tensor of shape ``(num_hyperedges, 1)`` containing the generated attribute for each hyperedge.
         """
         num_hyperedges = HyperedgeIndex(hyperedge_index).num_hyperedges
         hyperedge_attrs = torch.full(
@@ -150,7 +150,7 @@ class VilLainHyperedgeAttrsEnricher(_VilLainTrainer, HyperedgeAttrsEnricher):
             hyperedge_index: Hyperedge index tensor of shape ``(2, num_hyperedges)``.
 
         Returns:
-            Tensor of shape ``(num_hyperedges, num_features)`` containing VilLain hyperedge embeddings.
+            hyperedge_embeddings: Tensor of shape ``(num_hyperedges, num_features)`` containing VilLain hyperedge embeddings.
         """
         num_hyperedges = self._num_hyperedges(hyperedge_index)
         if num_hyperedges == 0:
@@ -202,7 +202,7 @@ class ABHyperedgeWeightsEnricher(HyperedgeWeightsEnricher):
             hyperedge_index: Hyperedge index tensor of shape ``(2, num_hyperedges)``.
 
         Returns:
-            Tensor of shape ``(num_hyperedges,)`` containing the weight of each hyperedge.
+            hyperedge_weight: Tensor of shape ``(num_hyperedges,)`` containing the weight of each hyperedge.
         """
         # Count the number of nodes in each hyperedge by counting occurrences of each hyperedge index.
         # Example: if hyperedge_index[1] = [0, 0, 1, 1, 1], then we have 2 nodes in hyperedge 0 and 3 nodes in hyperedge 1.
@@ -306,7 +306,7 @@ class Node2VecEnricher(NodeEnricher):
             hyperedge_index: Hyperedge index tensor of shape ``(2, num_hyperedges)``.
 
         Returns:
-            Tensor of shape ``(num_nodes, embedding_dim)`` containing the Node2Vec embeddings for each node.
+            x: Tensor of shape ``(num_nodes, embedding_dim)`` containing the Node2Vec embeddings for each node.
         """
         device = hyperedge_index.device
 
@@ -418,7 +418,7 @@ class LaplacianPositionalEncodingEnricher(NodeEnricher):
             hyperedge_index: Hyperedge index tensor of shape ``(2, num_hyperedges)``.
 
         Returns:
-            Tensor of shape ``(num_nodes, num_features)``.
+            node_features: Tensor of shape ``(num_nodes, num_features)``.
         """
         edge_index = HyperedgeIndex(hyperedge_index).reduce_to_edge_index_on_clique_expansion()
         edge_index_wrapper = EdgeIndex(edge_index)
@@ -524,7 +524,7 @@ class VilLainEnricher(_VilLainTrainer, NodeEnricher):
             hyperedge_index: Hyperedge index tensor of shape ``(2, num_hyperedges)``.
 
         Returns:
-            Tensor of shape ``(num_nodes, num_features)`` containing VilLain node embeddings.
+            node_embeddings: Tensor of shape ``(num_nodes, num_features)`` containing VilLain node embeddings.
         """
         num_nodes = self._num_nodes(hyperedge_index)
         if num_nodes == 0:

--- a/hyperbench/nn/loss.py
+++ b/hyperbench/nn/loss.py
@@ -27,7 +27,7 @@ class NHPRankingLoss(nn.Module):
             labels: Binary labels indicating positive (1) and negative (0) hyperedges, of shape ``(num_hyperedges,)``.
 
         Returns:
-            Scalar loss value.
+            loss: Scalar loss value.
         """
         # Split logits by label as we need to compare positive scores against negative scores.
         # Example: logits = [2.0, 1.0, -1.0]
@@ -94,7 +94,7 @@ class VilLainLoss:
             hyperedge_embeddings: Propagated hyperedge states with the same channel dimension as ``node_embeddings``.
 
         Returns:
-            Scalar tensor containing node plus hyperedge entropy losses.
+            loss: Scalar tensor containing node plus hyperedge entropy losses.
         """
         return self.entropy_loss(node_embeddings) + self.entropy_loss(hyperedge_embeddings)
 
@@ -110,7 +110,7 @@ class VilLainLoss:
             hyperedge_embeddings: Propagated hyperedge states with the same channel dimension as ``node_embeddings``.
 
         Returns:
-            Scalar tensor containing node plus hyperedge global losses.
+            loss: Scalar tensor containing node plus hyperedge global losses.
         """
         return (
             self.balance_loss(node_embeddings)
@@ -128,7 +128,7 @@ class VilLainLoss:
             global_loss: Accumulated balance plus distinctiveness loss.
 
         Returns:
-            Scalar tensor to minimize.
+            loss: Scalar tensor to minimize.
         """
         return local_loss + global_loss
 
@@ -140,7 +140,7 @@ class VilLainLoss:
             x: Flattened virtual-label probabilities of shape ``(num_items, num_subspaces * labels_per_subspace)``.
 
         Returns:
-            Scalar entropy loss.
+            loss: Scalar entropy loss.
         """
         if x.size(0) == 0:
             return x.sum() * 0.0
@@ -168,7 +168,7 @@ class VilLainLoss:
             x: Flattened virtual-label probabilities of shape ``(num_items, num_subspaces * labels_per_subspace)``.
 
         Returns:
-            Scalar balance loss.
+            loss: Scalar balance loss.
         """
         if x.size(0) == 0:
             return x.sum() * 0.0
@@ -198,7 +198,7 @@ class VilLainLoss:
             x: Flattened virtual-label probabilities of shape ``(num_items, num_subspaces * labels_per_subspace)``.
 
         Returns:
-            Scalar distinctiveness loss.
+            loss: Scalar distinctiveness loss.
         """
         if x.size(0) == 0:
             return x.sum() * 0.0

--- a/hyperbench/nn/scorer.py
+++ b/hyperbench/nn/scorer.py
@@ -44,7 +44,7 @@ class CommonNeighborsScorer(NeighborScorer):
             candidate_to_neighbors: Mapping from node IDs to their set of neighbors.
 
         Returns:
-            The aggregated common neighbors score.
+            score: The aggregated common neighbors score.
         """
         if len(candidate_nodes) < 2:
             return self.__DEFAULT_SCORE
@@ -76,7 +76,7 @@ class CommonNeighborsScorer(NeighborScorer):
             node_to_neighbors: Optional precomputed node to neighborhood mapping. If None, it will be computed from ``hyperedge_index``.
 
         Returns:
-            A 1-D tensor of shape ``(num_hyperedges,)`` with the CN score for each hyperedge.
+            scores: A 1-D tensor of shape ``(num_hyperedges,)`` with the CN score for each hyperedge.
         """
         if node_to_neighbors is None:
             node_to_neighbors = Hypergraph.from_hyperedge_index(hyperedge_index).neighbors_of_all()

--- a/hyperbench/train/markdown_logger.py
+++ b/hyperbench/train/markdown_logger.py
@@ -116,7 +116,7 @@ class MarkdownTableLogger(Logger):
         - anything else (e.g., "epoch") --> ignored
 
         Returns:
-            Tuple of (test_results, train_results, val_results), where each is a dict
+            results: Tuple of (test_results, train_results, val_results), where each is a dict
             mapping model names to their respective metric dicts. Models with no metrics
             in a category are excluded from that category's dict.
         """
@@ -186,7 +186,7 @@ class MarkdownTableLogger(Logger):
             precision: Number of decimal places for numeric metric values.
 
         Returns:
-            Markdown table string. Returns an empty string if ``results`` is empty.
+            table: Markdown table string. Returns an empty string if ``results`` is empty.
 
 
         """
@@ -241,7 +241,7 @@ class MarkdownTableLogger(Logger):
             precision: Decimal places for metric values.
 
         Returns:
-            Path to the written file.
+            path: Path to the written file.
         """
         sections = []
 

--- a/hyperbench/train/negative_sampler.py
+++ b/hyperbench/train/negative_sampler.py
@@ -33,7 +33,7 @@ class NegativeSampler(ABC):
             seed: Optional random seed for reproducible negative sampling.
 
         Returns:
-            hdata: The negative samples as a new :class:`HData` object.
+            hdata: The negative samples as a new `HData` object.
 
         Raises:
             NotImplementedError: If the method is not implemented in a subclass.
@@ -119,7 +119,7 @@ class NegativeSampler(ABC):
         Generate enriched hyperedge attributes for the negative samples.
 
         Args:
-            hyperedge_attr_enricher: An optional :class:`HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
+            hyperedge_attr_enricher: An optional `HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
             negative_hyperedge_index: The index tensor for the negative hyperedges.
 
         Returns:
@@ -142,7 +142,7 @@ class NegativeSampler(ABC):
         Generate enriched hyperedge weights for the negative samples.
 
         Args:
-            hyperedge_weights_enricher: An optional :class:`HyperedgeWeightsEnricher` to generate weights for the new hyperedges.
+            hyperedge_weights_enricher: An optional `HyperedgeWeightsEnricher` to generate weights for the new hyperedges.
             negative_hyperedge_index: The index tensor for the negative hyperedges.
 
         Returns:
@@ -241,8 +241,8 @@ class SameNodeSpaceNegativeSampler(NegativeSampler, ABC):
     Base class for negative samplers that sample only from existing nodes.
 
     Args:
-        hyperedge_attr_enricher: An optional :class:`HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
-        hyperedge_weights_enricher: An optional :class:`HyperedgeWeightsEnricher` to generate weights for the new hyperedges.
+        hyperedge_attr_enricher: An optional `HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
+        hyperedge_weights_enricher: An optional `HyperedgeWeightsEnricher` to generate weights for the new hyperedges.
         return_0based_negatives:
             - If ``True``, the negative samples returned by the ``sample`` method will have 0-based node and hyperedge IDs.
             - If ``False``, the negative samples will retain the original global node and hyperedge IDs from the input data.
@@ -264,9 +264,9 @@ class GeneratedNodesNegativeSampler(NegativeSampler, ABC):
     Base class for negative samplers that generate new nodes instead of sampling from existing ones.
 
     Args:
-        node_feature_enricher: A :class:`NodeEnricher` to generate features for the new nodes.
-        hyperedge_attr_enricher: An optional :class:`HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
-        hyperedge_weights_enricher: An optional :class:`HyperedgeWeightsEnricher` to generate weights for the new hyperedges.
+        node_feature_enricher: A `NodeEnricher` to generate features for the new nodes.
+        hyperedge_attr_enricher: An optional `HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
+        hyperedge_weights_enricher: An optional `HyperedgeWeightsEnricher` to generate weights for the new hyperedges.
         return_0based_negatives:
             - If ``True``, the negative samples returned by the ``sample`` method will have 0-based node and hyperedge IDs.
             - If ``False``, the negative samples will retain the original global node and hyperedge IDs from the input data.
@@ -288,16 +288,16 @@ class GeneratedNodesNegativeSampler(NegativeSampler, ABC):
 class RandomNegativeSampler(SameNodeSpaceNegativeSampler):
     """
     A random negative sampler. Negatives generated with ``return_0based_negatives = False`` aren't usable standalone
-    as they have global node and hyperedge IDs. They must be concatenated with the original :class:`HData` object
+    as they have global node and hyperedge IDs. They must be concatenated with the original `HData` object
     that is provided as input to the ``sample`` method, as it contains the global node and hyperedge IDs and features
     that can be indexed with the negative samples' IDs.
 
     Args:
         num_negative_samples: Number of negative hyperedges to generate.
         num_nodes_per_sample: Number of nodes per negative hyperedge.
-        hyperedge_attr_enricher: An optional :class:`HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
+        hyperedge_attr_enricher: An optional `HyperedgeAttrsEnricher` to generate attributes for the new hyperedges.
             If not provided, random attributes will be generated for the negative hyperedges if the input data has hyperedge attributes.
-        hyperedge_weights_enricher: An optional :class:`HyperedgeEnricher` to generate weights for the new hyperedges.
+        hyperedge_weights_enricher: An optional `HyperedgeEnricher` to generate weights for the new hyperedges.
             If not provided, the negative hyperedges will not have weights.
         return_0based_negatives:
             - If ``True``, the negative samples returned by the ``sample`` method will have 0-based node and hyperedge IDs.
@@ -339,7 +339,7 @@ class RandomNegativeSampler(SameNodeSpaceNegativeSampler):
         Generate negative hyperedges by randomly sampling unique node IDs.
         Node IDs are sampled from the same node space as the input data, and the new negative hyperedge IDs
         start from the original number of hyperedges in the input data to avoid ID conflicts.
-        The resulting negative samples are returned as a new :class:`HData` object with remapped 0-based node and hyperedge IDs, if ``self.return_0based_negatives == True``.
+        The resulting negative samples are returned as a new `HData` object with remapped 0-based node and hyperedge IDs, if ``self.return_0based_negatives == True``.
         Otherwise, the negative samples retain their original global node and hyperedge IDs from the input data.
 
         Examples:
@@ -372,7 +372,7 @@ class RandomNegativeSampler(SameNodeSpaceNegativeSampler):
             seed: Optional random seed for reproducible negative sampling.
 
         Returns:
-            hdata: A new :class:`HData` instance containing the negative samples.
+            hdata: A new `HData` instance containing the negative samples.
 
         Raises:
             ValueError: If ``num_nodes_per_sample`` is greater than the number of available nodes.
@@ -650,7 +650,7 @@ class CliqueNegativeSampler(SameNodeSpaceNegativeSampler):
             seed: Optional random seed for reproducible candidate selection.
 
         Returns:
-            hdata: A new :class:`HData` instance containing only sampled negative hyperedges.
+            hdata: A new `HData` instance containing only sampled negative hyperedges.
 
         Raises:
             ValueError: If too few nodes or valid clique negatives are available.

--- a/hyperbench/train/negative_sampler.py
+++ b/hyperbench/train/negative_sampler.py
@@ -33,7 +33,7 @@ class NegativeSampler(ABC):
             seed: Optional random seed for reproducible negative sampling.
 
         Returns:
-            The negative samples as a new :class:`HData` object.
+            hdata: The negative samples as a new :class:`HData` object.
 
         Raises:
             NotImplementedError: If the method is not implemented in a subclass.
@@ -55,7 +55,7 @@ class NegativeSampler(ABC):
             negative_hyperedge_ids: Tensor of negative hyperedge IDs.
 
         Returns:
-            The concatenated, sorted, and remapped hyperedge index tensor.
+            hyperedge_index: The concatenated, sorted, and remapped hyperedge index tensor.
             If ``self.return_0based_negatives`` is ``True``, the returned tensor will have 0-based node and hyperedge IDs.
             Otherwise, it will retain the original global node and hyperedge IDs from the input data.
         """
@@ -83,7 +83,7 @@ class NegativeSampler(ABC):
             negative_node_ids: Tensor of negative node IDs.
 
         Returns:
-            The global node IDs for the negative samples, or ``None`` if the input global node IDs are ``None``.
+            global_node_ids: The global node IDs for the negative samples, or ``None`` if the input global node IDs are ``None``.
         """
         if global_node_ids is None:
             return None
@@ -102,7 +102,7 @@ class NegativeSampler(ABC):
             hyperedge_attr: The original hyperedge attributes from the input data.
 
         Returns:
-            The concatenated hyperedge attribute tensor for the negative samples.
+            hyperedge_attr: The concatenated hyperedge attribute tensor for the negative samples.
         """
         if hyperedge_attr is None or len(sampled_hyperedge_attrs) < 1:
             return None
@@ -123,7 +123,7 @@ class NegativeSampler(ABC):
             negative_hyperedge_index: The index tensor for the negative hyperedges.
 
         Returns:
-            The enriched hyperedge attribute tensor for the negative samples, or ``None`` if the enricher is not provided.
+            hyperedge_attr: The enriched hyperedge attribute tensor for the negative samples, or ``None`` if the enricher is not provided.
         """
         if hyperedge_attr_enricher is None:
             return None
@@ -146,7 +146,7 @@ class NegativeSampler(ABC):
             negative_hyperedge_index: The index tensor for the negative hyperedges.
 
         Returns:
-            The enriched hyperedge weight tensor for the negative samples, or ``None`` if the enricher is not provided.
+            hyperedge_weights: The enriched hyperedge weight tensor for the negative samples, or ``None`` if the enricher is not provided.
         """
         if hyperedge_weights_enricher is None:
             return None
@@ -165,7 +165,7 @@ class NegativeSampler(ABC):
             negative_node_ids: Tensor of negative node IDs.
 
         Returns:
-            The node feature matrix for the negative samples and the number of negative nodes.
+            x_and_num_negative_nodes: The node feature matrix for the negative samples and the number of negative nodes.
         """
         return x[negative_node_ids], len(negative_node_ids)
 
@@ -185,7 +185,7 @@ class NegativeSampler(ABC):
             device: Device where the returned tensor should be allocated.
 
         Returns:
-            A tensor containing consecutive negative hyperedge IDs.
+            hyperedge_ids: A tensor containing consecutive negative hyperedge IDs.
         """
         # Example: new_hyperedge_id_offset = 3 (if hdata.num_hyperedges was 3)
         #          num_negative_samples = 2
@@ -206,7 +206,7 @@ class NegativeSampler(ABC):
                 and hyperedge IDs.
 
         Returns:
-            A set of sorted node ID tuples, one tuple per hyperedge.
+            signatures: A set of sorted node ID tuples, one tuple per hyperedge.
         """
         all_hyperedge_ids = hyperedge_index[1]
         unique_hyperedge_ids = all_hyperedge_ids.unique().tolist()
@@ -229,7 +229,7 @@ class NegativeSampler(ABC):
             node_ids: A tensor or sequence containing node IDs for one hyperedge.
 
         Returns:
-            A sorted tuple of Python ``int`` values.
+            signature: A sorted tuple of Python ``int`` values.
         """
         if isinstance(node_ids, Tensor):
             return tuple(sorted(int(node_id) for node_id in node_ids.tolist()))
@@ -372,7 +372,7 @@ class RandomNegativeSampler(SameNodeSpaceNegativeSampler):
             seed: Optional random seed for reproducible negative sampling.
 
         Returns:
-            A new :class:`HData` instance containing the negative samples.
+            hdata: A new :class:`HData` instance containing the negative samples.
 
         Raises:
             ValueError: If ``num_nodes_per_sample`` is greater than the number of available nodes.
@@ -467,7 +467,7 @@ class RandomNegativeSampler(SameNodeSpaceNegativeSampler):
             seed: Optional random seed for reproducible sampling.
 
         Returns:
-            A tuple containing sampled hyperedge index tensors, sampled hyperedge attribute
+            samples: A tuple containing sampled hyperedge index tensors, sampled hyperedge attribute
             tensors, sampled node IDs, and the first negative hyperedge ID.
 
         Raises:
@@ -650,7 +650,7 @@ class CliqueNegativeSampler(SameNodeSpaceNegativeSampler):
             seed: Optional random seed for reproducible candidate selection.
 
         Returns:
-            A new :class:`HData` instance containing only sampled negative hyperedges.
+            hdata: A new :class:`HData` instance containing only sampled negative hyperedges.
 
         Raises:
             ValueError: If too few nodes or valid clique negatives are available.
@@ -762,7 +762,7 @@ class CliqueNegativeSampler(SameNodeSpaceNegativeSampler):
             enumerated_candidates: Number of full-size clique candidates visited so far.
 
         Returns:
-            Updated number of full-size clique candidates visited.
+            visited: Updated number of full-size clique candidates visited.
 
         Raises:
             ValueError: If ``max_candidates`` is set and clique enumeration exceeds it.
@@ -818,7 +818,7 @@ class CliqueNegativeSampler(SameNodeSpaceNegativeSampler):
             positive_hyperedge_signatures: Positive hyperedge node signatures with the requested sample size.
 
         Returns:
-            Clique node signatures that are not positive hyperedges.
+            candidates: Clique node signatures that are not positive hyperedges.
 
         Raises:
             ValueError: If fewer valid clique negatives exist than requested, or if
@@ -864,7 +864,7 @@ class CliqueNegativeSampler(SameNodeSpaceNegativeSampler):
             seed: Optional seed for reproducible candidate shuffling and random attributes.
 
         Returns:
-            A tuple containing sampled hyperedge index tensors, sampled hyperedge
+            samples: A tuple containing sampled hyperedge index tensors, sampled hyperedge
             attribute tensors, sampled node IDs, and the first negative hyperedge ID.
         """
         device = hdata.device

--- a/hyperbench/train/negative_sampling_scheduler.py
+++ b/hyperbench/train/negative_sampling_scheduler.py
@@ -55,7 +55,7 @@ class NegativeSamplingScheduler:
             epoch: The current epoch number, used to determine if sampling should occur based on the schedule.
 
         Returns:
-            True if negatives should be resampled for the current epoch, False otherwise.
+            should_sample: True if negatives should be resampled for the current epoch, False otherwise.
         """
         match self.negative_sampling_schedule:
             case NegativeSamplingSchedule.EVERY_N_EPOCHS:
@@ -74,7 +74,7 @@ class NegativeSamplingScheduler:
             epoch: The current epoch number, used to determine if sampling should occur based on the schedule.
 
         Returns:
-            A batch of negative samples, either freshly sampled or from cache.
+            negatives: A batch of negative samples, either freshly sampled or from cache.
         """
         if self.should_sample(epoch):
             self.__cached_negative_samples = self.negative_sampler.sample(batch)

--- a/hyperbench/types/graph.py
+++ b/hyperbench/types/graph.py
@@ -48,7 +48,7 @@ class Graph:
         Remove self-loops from the graph.
 
         Returns:
-            List of edges without self-loops.
+            edges: List of edges without self-loops.
         """
         if self.num_edges == 0:
             return self
@@ -119,7 +119,7 @@ class Graph:
             drop_rate: Randomly dropout the connections in the Laplacian with probability ``drop_rate``. Defaults to ``0.0``.
 
         Returns:
-            The smoothed feature matrix. Size ``(num_nodes, C)``.
+            x: The smoothed feature matrix. Size ``(num_nodes, C)``.
         """
         if drop_rate > 0.0:
             laplacian_matrix = utils.sparse_dropout(laplacian_matrix, drop_rate)
@@ -218,7 +218,7 @@ class EdgeIndex:
             with_duplicate_removal: Whether to remove duplicate edges after adding self-loops. Defaults to ``True``.
 
         Returns:
-            This :class:`EdgeIndex` instance with self-loops added.
+            edge_index: This :class:`EdgeIndex` instance with self-loops added.
 
         Raises:
             ValueError: If the input edge index has no edges (i.e., ``shape (2, 0)``).
@@ -298,7 +298,7 @@ class EdgeIndex:
                 If ``False``, all edges will have weight 1. Defaults to ``False``.
 
         Returns:
-            The sparse adjacency matrix of shape ``(num_nodes, num_nodes)``.
+            adjacency: The sparse adjacency matrix of shape ``(num_nodes, num_nodes)``.
         """
         device = self.__edge_index.device
         src, dest = self.__edge_index
@@ -346,7 +346,7 @@ class EdgeIndex:
                 If ``None``, it will be inferred from ``self.num_nodes``.
 
         Returns:
-            The sparse identity matrix I of shape ``(num_nodes, num_nodes)``.
+            identity: The sparse identity matrix I of shape ``(num_nodes, num_nodes)``.
         """
         device = self.__edge_index.device
         num_nodes = self.num_nodes if num_nodes is None else num_nodes
@@ -383,7 +383,7 @@ class EdgeIndex:
             use_edge_weights: If ``True``, use the edge weights from ``self.edge_weights``. If ``False``, all edges use weight 1.
 
         Returns:
-            The sparse normalized degree matrix D^-1/2 of shape ``(num_nodes, num_nodes)``.
+            degree_matrix: The sparse normalized degree matrix D^-1/2 of shape ``(num_nodes, num_nodes)``.
         """
         device = self.__edge_index.device
 
@@ -436,7 +436,7 @@ class EdgeIndex:
                 it will be inferred from ``self.num_nodes``.
 
         Returns:
-            The sparse symmetric normalized Laplacian matrix of shape ``(num_nodes, num_nodes)``.
+            laplacian: The sparse symmetric normalized Laplacian matrix of shape ``(num_nodes, num_nodes)``.
         """
         self.to_undirected(with_selfloops=False)
 
@@ -475,7 +475,7 @@ class EdgeIndex:
             use_edge_weights: If ``True``, use the edge weights from ``self.edge_weights``. If ``False``, all edges use weight 1.
 
         Returns:
-            The sparse symmetrically normalized Laplacian matrix of shape ``(num_nodes, num_nodes)``.
+            laplacian: The sparse symmetrically normalized Laplacian matrix of shape ``(num_nodes, num_nodes)``.
         """
         self.to_undirected(with_selfloops=True, num_nodes=num_nodes)
 
@@ -518,7 +518,7 @@ class EdgeIndex:
                 as it ensures that the resulting Laplacian matrix has the correct size and includes all nodes. For instance, for self-loops.
 
         Returns:
-            This :class:`EdgeIndex` instance with duplicate edges removed.
+            edge_index: This :class:`EdgeIndex` instance with duplicate edges removed.
         """
         # Example: edge_index = [[0, 1, 2, 2, 0, 3, 2],
         #                        [1, 0, 3, 2, 1, 2, 2]], shape (2, |E| = 7)
@@ -572,7 +572,7 @@ class EdgeIndex:
                 as it ensures that the resulting Laplacian matrix has the correct size and includes all nodes. For instance, for self-loops.
 
         Returns:
-            This :class:`EdgeIndex` instance converted to undirected.
+            edge_index: This :class:`EdgeIndex` instance converted to undirected.
         """
         device = self.__edge_index.device
         num_nodes = self.num_nodes if num_nodes is None else num_nodes

--- a/hyperbench/types/graph.py
+++ b/hyperbench/types/graph.py
@@ -218,7 +218,7 @@ class EdgeIndex:
             with_duplicate_removal: Whether to remove duplicate edges after adding self-loops. Defaults to ``True``.
 
         Returns:
-            edge_index: This :class:`EdgeIndex` instance with self-loops added.
+            edge_index: This `EdgeIndex` instance with self-loops added.
 
         Raises:
             ValueError: If the input edge index has no edges (i.e., ``shape (2, 0)``).
@@ -518,7 +518,7 @@ class EdgeIndex:
                 as it ensures that the resulting Laplacian matrix has the correct size and includes all nodes. For instance, for self-loops.
 
         Returns:
-            edge_index: This :class:`EdgeIndex` instance with duplicate edges removed.
+            edge_index: This `EdgeIndex` instance with duplicate edges removed.
         """
         # Example: edge_index = [[0, 1, 2, 2, 0, 3, 2],
         #                        [1, 0, 3, 2, 1, 2, 2]], shape (2, |E| = 7)
@@ -572,7 +572,7 @@ class EdgeIndex:
                 as it ensures that the resulting Laplacian matrix has the correct size and includes all nodes. For instance, for self-loops.
 
         Returns:
-            edge_index: This :class:`EdgeIndex` instance converted to undirected.
+            edge_index: This `EdgeIndex` instance converted to undirected.
         """
         device = self.__edge_index.device
         num_nodes = self.num_nodes if num_nodes is None else num_nodes

--- a/hyperbench/types/hdata.py
+++ b/hyperbench/types/hdata.py
@@ -138,7 +138,7 @@ class HData:
                 If ``None``, the node features from the instance with the largest number of nodes will be used.
 
         Returns:
-            A new :class:`HData` with shared nodes and concatenated hyperedges.
+            hdata: A new :class:`HData` with shared nodes and concatenated hyperedges.
 
         Raises:
             ValueError: If the node counts do not match across inputs.
@@ -194,7 +194,7 @@ class HData:
             seed: Optional random seed used for both negative sampling and the final shuffle.
 
         Returns:
-            A new :class:`HData` containing the original hyperedges and sampled negatives.
+            hdata: A new :class:`HData` containing the original hyperedges and sampled negatives.
         """
         neg_hdata = negative_sampler.sample(self, seed=seed)
         hdata_with_negatives = self.cat_same_node_space([self, neg_hdata])
@@ -236,7 +236,7 @@ class HData:
             hyperedge_index: Tensor of shape ``[2, num_incidences]`` representing the hypergraph connectivity.
 
         Returns:
-            An :class:`HData` instance with the given hyperedge index and default values for other attributes.
+            hdata: An :class:`HData` instance with the given hyperedge index and default values for other attributes.
         """
         return cls(
             x=empty_nodefeatures(),
@@ -277,7 +277,7 @@ class HData:
                 while ``inductive`` allows splits to have disjoint node spaces.
 
         Returns:
-            The splitted instance with remapped node and hyperedge IDs.
+            hdata: The splitted instance with remapped node and hyperedge IDs.
         """
         # Mask to keep only incidences belonging to selected hyperedges
         # Example: hyperedge_index = [[0, 0, 1, 2, 3, 4],
@@ -424,7 +424,7 @@ class HData:
             fill_value: Scalar or vector used to fill missing node features when ``node_space_setting`` is not transductive.
 
         Returns:
-            A new :class:`HData` with node features copied from ``hdata_with_features``.
+            hdata: A new :class:`HData` with node features copied from ``hdata_with_features``.
 
         Raises:
             ValueError: If either instance lacks ``global_node_ids``, if the source feature rows
@@ -582,7 +582,7 @@ class HData:
         If there are no tensors or if they are on different devices, return CPU.
 
         Returns:
-            The common device if all tensors are on the same device, otherwise CPU.
+            device: The common device if all tensors are on the same device, otherwise CPU.
 
         Raises:
             ValueError: If tensors are on different devices.
@@ -652,7 +652,7 @@ class HData:
             seed: Optional random seed for reproducibility. If ``None``, the shuffle will be non-deterministic.
 
         Returns:
-            A new :class:`HData` instance with hyperedge IDs, ``y``, and ``hyperedge_attr`` permuted.
+            hdata: A new :class:`HData` instance with hyperedge IDs, ``y``, and ``hyperedge_attr`` permuted.
         """
         generator = torch.Generator(device=self.device)
         if seed is not None:
@@ -707,7 +707,7 @@ class HData:
         Return a deep copy of this :class:`HData`.
 
         Returns:
-            A new :class:`HData` that is a deep copy of this instance.
+            hdata: A new :class:`HData` that is a deep copy of this instance.
         """
         cloned_hyperedge_weights = (
             self.hyperedge_weights.clone() if self.hyperedge_weights is not None else None
@@ -738,7 +738,7 @@ class HData:
             non_blocking: If ``True`` and the source and destination devices are both CUDA, the copy will be non-blocking.
 
         Returns:
-            The :class:`HData` instance with all tensors moved to the specified device.
+            hdata: The :class:`HData` instance with all tensors moved to the specified device.
         """
         self.x = self.x.to(device=device, non_blocking=non_blocking)
         self.hyperedge_index = self.hyperedge_index.to(device=device, non_blocking=non_blocking)
@@ -766,7 +766,7 @@ class HData:
             value: The value to set for all entries in the y attribute.
 
         Returns:
-            A new :class:`HData` instance with the same attributes except for y, which is set to a tensor of the given value.
+            hdata: A new :class:`HData` instance with the same attributes except for y, which is set to a tensor of the given value.
         """
         return self.__class__(
             x=self.x,
@@ -810,7 +810,7 @@ class HData:
         - ``distribution_hyperedge_size_hist``: A dictionary where the keys are hyperedge sizes and the values are the count of hyperedges with that size.
 
         Returns:
-            A dictionary containing various statistics about the hypergraph.
+            stats: A dictionary containing various statistics about the hypergraph.
         """
 
         node_ids = self.hyperedge_index[0]

--- a/hyperbench/types/hdata.py
+++ b/hyperbench/types/hdata.py
@@ -114,7 +114,7 @@ class HData:
     @classmethod
     def cat_same_node_space(cls, hdatas: Sequence["HData"], x: Tensor | None = None) -> "HData":
         """
-        Concatenate :class:`HData` instances that share the same node space, meaning nodes with the same ID in different instances are the same node.
+        Concatenate `HData` instances that share the same node space, meaning nodes with the same ID in different instances are the same node.
         This is useful when combining positive and negative hyperedges that reference the same set of nodes.
 
         Notes:
@@ -133,12 +133,12 @@ class HData:
             >>> new.num_hyperedges  # 4 — hyperedges [0, 1, 2, 3]
 
         Args:
-            hdatas: One or more :class:`HData` instances sharing the same node space.
-            x: Optional node feature matrix to use for the resulting :class:`HData`.
+            hdatas: One or more `HData` instances sharing the same node space.
+            x: Optional node feature matrix to use for the resulting `HData`.
                 If ``None``, the node features from the instance with the largest number of nodes will be used.
 
         Returns:
-            hdata: A new :class:`HData` with shared nodes and concatenated hyperedges.
+            hdata: A new `HData` with shared nodes and concatenated hyperedges.
 
         Raises:
             ValueError: If the node counts do not match across inputs.
@@ -187,14 +187,14 @@ class HData:
         seed: int | None = None,
     ) -> "HData":
         """
-        Return a new :class:`HData` with sampled negative hyperedges added.
+        Return a new `HData` with sampled negative hyperedges added.
 
         Args:
             negative_sampler: Sampler used to generate negative hyperedges from this instance.
             seed: Optional random seed used for both negative sampling and the final shuffle.
 
         Returns:
-            hdata: A new :class:`HData` containing the original hyperedges and sampled negatives.
+            hdata: A new `HData` containing the original hyperedges and sampled negatives.
         """
         neg_hdata = negative_sampler.sample(self, seed=seed)
         hdata_with_negatives = self.cat_same_node_space([self, neg_hdata])
@@ -216,7 +216,7 @@ class HData:
     @classmethod
     def from_hyperedge_index(cls, hyperedge_index: Tensor) -> "HData":
         """
-        Build an :class:`HData` from a given hyperedge index, with empty node features and hyperedge attributes.
+        Build an `HData` from a given hyperedge index, with empty node features and hyperedge attributes.
 
         - Node features are initialized as an empty tensor of shape ``[0, 0]``.
         - Hyperedge attributes are set to ``None``.
@@ -236,7 +236,7 @@ class HData:
             hyperedge_index: Tensor of shape ``[2, num_incidences]`` representing the hypergraph connectivity.
 
         Returns:
-            hdata: An :class:`HData` instance with the given hyperedge index and default values for other attributes.
+            hdata: An `HData` instance with the given hyperedge index and default values for other attributes.
         """
         return cls(
             x=empty_nodefeatures(),
@@ -255,7 +255,7 @@ class HData:
         node_space_setting: NodeSpaceSetting = "transductive",
     ) -> "HData":
         """
-        Build an :class:`HData` for a single split from the given hyperedge IDs.
+        Build an `HData` for a single split from the given hyperedge IDs.
 
         Examples:
             Transductive split (default) preserving the full node space:
@@ -270,7 +270,7 @@ class HData:
             ... 2
 
         Args:
-            hdata: The original :class:`HData` containing the full hypergraph.
+            hdata: The original `HData` containing the full hypergraph.
             split_hyperedge_ids: Tensor of hyperedge IDs to include in this split.
             node_space_setting: Whether to preserve the full node space in the splits.
                 ``transductive`` (default) ensures all nodes are present in every split,
@@ -396,7 +396,7 @@ class HData:
         fill_value: NodeSpaceFiller | None = None,
     ) -> "HData":
         """
-        Copy node features from another :class:`HData` by aligning features by ``global_node_ids``.
+        Copy node features from another `HData` by aligning features by ``global_node_ids``.
 
         Examples:
             Transductive enrichment (default) expecting the same node space in both source and target:
@@ -417,14 +417,14 @@ class HData:
             ... )
 
         Args:
-            hdata_with_features: Source :class:`HData` providing node features.
+            hdata_with_features: Source `HData` providing node features.
             node_space_setting: The setting for the node space, determining how nodes are handled.
                 If ``"transductive"``, every target node is expected to exist in the source.
                 If ``"inductive"``, the target dataset may have a different node space, and missing nodes are filled using ``fill_value``.
             fill_value: Scalar or vector used to fill missing node features when ``node_space_setting`` is not transductive.
 
         Returns:
-            hdata: A new :class:`HData` with node features copied from ``hdata_with_features``.
+            hdata: A new `HData` with node features copied from ``hdata_with_features``.
 
         Raises:
             ValueError: If either instance lacks ``global_node_ids``, if the source feature rows
@@ -631,7 +631,7 @@ class HData:
 
     def shuffle(self, seed: int | None = None) -> "HData":
         """
-        Return a new :class:`HData` instance with hyperedge IDs randomly reassigned.
+        Return a new `HData` instance with hyperedge IDs randomly reassigned.
 
         Each hyperedge keeps its original set of nodes, but is assigned a new ID via a random permutation.
         ``y`` and ``hyperedge_attr`` are reordered to match, so that ``y[new_id]`` still corresponds to the correct hyperedge.
@@ -652,7 +652,7 @@ class HData:
             seed: Optional random seed for reproducibility. If ``None``, the shuffle will be non-deterministic.
 
         Returns:
-            hdata: A new :class:`HData` instance with hyperedge IDs, ``y``, and ``hyperedge_attr`` permuted.
+            hdata: A new `HData` instance with hyperedge IDs, ``y``, and ``hyperedge_attr`` permuted.
         """
         generator = torch.Generator(device=self.device)
         if seed is not None:
@@ -704,10 +704,10 @@ class HData:
 
     def clone(self) -> "HData":
         """
-        Return a deep copy of this :class:`HData`.
+        Return a deep copy of this `HData`.
 
         Returns:
-            hdata: A new :class:`HData` that is a deep copy of this instance.
+            hdata: A new `HData` that is a deep copy of this instance.
         """
         cloned_hyperedge_weights = (
             self.hyperedge_weights.clone() if self.hyperedge_weights is not None else None
@@ -738,7 +738,7 @@ class HData:
             non_blocking: If ``True`` and the source and destination devices are both CUDA, the copy will be non-blocking.
 
         Returns:
-            hdata: The :class:`HData` instance with all tensors moved to the specified device.
+            hdata: The `HData` instance with all tensors moved to the specified device.
         """
         self.x = self.x.to(device=device, non_blocking=non_blocking)
         self.hyperedge_index = self.hyperedge_index.to(device=device, non_blocking=non_blocking)
@@ -766,7 +766,7 @@ class HData:
             value: The value to set for all entries in the y attribute.
 
         Returns:
-            hdata: A new :class:`HData` instance with the same attributes except for y, which is set to a tensor of the given value.
+            hdata: A new `HData` instance with the same attributes except for y, which is set to a tensor of the given value.
         """
         return self.__class__(
             x=self.x,

--- a/hyperbench/types/hypergraph.py
+++ b/hyperbench/types/hypergraph.py
@@ -923,7 +923,7 @@ class HyperedgeIndex:
             k: The minimum number of nodes a hyperedge must contain to be kept.
 
         Returns:
-            hyperedge_index: A new :class:`HyperedgeIndex` instance with hyperedges containing fewer than k nodes.
+            hyperedge_index: A new `HyperedgeIndex` instance with hyperedges containing fewer than k nodes.
         """
         _, idx_to_hyperedge_id, num_nodes_per_hyperedge = torch.unique(
             self.all_hyperedge_ids,
@@ -949,7 +949,7 @@ class HyperedgeIndex:
                 If ``None``, all hyperedge IDs in the hyperedge index will be rebased to 0-based format based on their unique sorted order.
 
         Returns:
-            hyperedge_index: A new :class:`HyperedgeIndex` instance with the hyperedge index converted to 0-based format.
+            hyperedge_index: A new `HyperedgeIndex` instance with the hyperedge index converted to 0-based format.
         """
         # Example: hyperedge_index after sorting: [[0, 0, 1, 2, 3, 4],
         #                                          [3, 4, 4, 3, 4, 3]]

--- a/hyperbench/types/hypergraph.py
+++ b/hyperbench/types/hypergraph.py
@@ -57,7 +57,7 @@ class HIFHypergraph:
             data: Dictionary with keys: network-type, metadata, incidences, nodes, hyperedges
 
         Returns:
-            Hypergraph instance
+            hypergraph: Hypergraph instance
         """
         network_type = data.get("network-type") or data.get("network_type")
         metadata = data.get("metadata", {})
@@ -103,7 +103,7 @@ class HIFHypergraph:
         - ``distribution_hyperedge_size_hist``: A dictionary where the keys are hyperedge sizes and the values are the count of hyperedges with that size.
 
         Returns:
-            A dictionary containing various statistics about the hypergraph.
+            stats: A dictionary containing various statistics about the hypergraph.
         """
 
         node_degree: dict[Any, int] = {}
@@ -220,7 +220,7 @@ class Hypergraph:
             node: The node ID to find neighbors for.
 
         Returns:
-            A set of neighbor node IDs (excluding the node itself).
+            neighbors: A set of neighbor node IDs (excluding the node itself).
         """
         neighbors: Neighborhood = set()
         for hyperedge in self.hyperedges:
@@ -238,7 +238,7 @@ class Hypergraph:
         more efficient when scoring many candidate hyperedges.
 
         Returns:
-            A dictionary mapping each node ID to its set of neighbors.
+            neighbors: A dictionary mapping each node ID to its set of neighbors.
         """
         nodes: set[int] = set()
         for hyperedge in self.hyperedges:
@@ -332,7 +332,7 @@ class Hypergraph:
             hyperedge_index: Tensor of shape (2, |E|) representing hyperedges, where each column is (node, hyperedge).
 
         Returns:
-            Hypergraph instance
+            hypergraph: Hypergraph instance
         """
         if hyperedge_index.size(1) < 1:
             return cls(hyperedges=[])
@@ -361,7 +361,7 @@ class Hypergraph:
             drop_rate: Randomly dropout the connections in the smoothing matrix with probability ``drop_rate``. Defaults to ``0.0``.
 
         Returns:
-            The smoothed feature matrix. Size ``(num_nodes, C)``.
+            x: The smoothed feature matrix. Size ``(num_nodes, C)``.
         """
         if drop_rate > 0.0:
             matrix = sparse_dropout(matrix, drop_rate)
@@ -453,7 +453,7 @@ class HyperedgeIndex:
             num_nodes: The total number of nodes in the hypergraph, including isolated nodes.
 
         Returns:
-            The number of nodes in the hypergraph, which is the maximum of the number of unique nodes in the hyperedge index and the provided ``num_nodes``.
+            num_nodes: The number of nodes in the hypergraph, which is the maximum of the number of unique nodes in the hyperedge index and the provided ``num_nodes``.
         """
         return max(self.num_nodes, num_nodes)
 
@@ -469,7 +469,7 @@ class HyperedgeIndex:
                 If ``None``, inferred from the unique node IDs in ``hyperedge_index``.
 
         Returns:
-            A list where ``adjacency[node_id]`` is the set of nodes adjacent to ``node_id``.
+            adjacency: A list where ``adjacency[node_id]`` is the set of nodes adjacent to ``node_id``.
         """
         num_nodes = num_nodes if num_nodes is not None else self.num_nodes
         adjacency_list: list[set[int]] = [set() for _ in range(num_nodes)]
@@ -506,7 +506,7 @@ class HyperedgeIndex:
             num_hyperedges: Total number of hyperedges. If ``None``, inferred from hyperedge index.
 
         Returns:
-            The sparse incidence matrix H of shape ``(num_nodes, num_hyperedges)``.
+            incidence_matrix: The sparse incidence matrix H of shape ``(num_nodes, num_hyperedges)``.
         """
         device = self.__hyperedge_index.device
         num_nodes = num_nodes if num_nodes is not None else self.num_nodes
@@ -536,7 +536,7 @@ class HyperedgeIndex:
             num_nodes: Total number of nodes. If ``None``, inferred from hyperedge index.
 
         Returns:
-            The sparse diagonal matrix of shape ``(num_nodes, num_nodes)``.
+            degree_matrix: The sparse diagonal matrix of shape ``(num_nodes, num_nodes)``.
         """
         device = self.__hyperedge_index.device
         num_nodes = num_nodes if num_nodes is not None else self.num_nodes
@@ -568,7 +568,7 @@ class HyperedgeIndex:
             num_nodes: Total number of nodes. If ``None``, inferred from hyperedge index.
 
         Returns:
-            The sparse diagonal matrix D_n^-1 of shape ``(num_nodes, num_nodes)``.
+            degree_matrix: The sparse diagonal matrix D_n^-1 of shape ``(num_nodes, num_nodes)``.
         """
         # Example: hyperedge_index = [[0, 1, 2, 0],
         #                             [0, 0, 0, 1]]
@@ -600,7 +600,7 @@ class HyperedgeIndex:
             num_nodes: Total number of nodes. If ``None``, inferred from hyperedge index.
 
         Returns:
-            The sparse diagonal matrix D_n^-1/2 of shape ``(num_nodes, num_nodes)``.
+            degree_matrix: The sparse diagonal matrix D_n^-1/2 of shape ``(num_nodes, num_nodes)``.
         """
         # Example: hyperedge_index = [[0, 1, 2, 0],
         #                             [0, 0, 0, 1]]
@@ -633,7 +633,7 @@ class HyperedgeIndex:
             num_hyperedges: Total number of hyperedges. If ``None``, inferred from hyperedge index.
 
         Returns:
-            The sparse diagonal matrix D_e^-1 of shape ``(num_hyperedges, num_hyperedges)``.
+            degree_matrix: The sparse diagonal matrix D_e^-1 of shape ``(num_hyperedges, num_hyperedges)``.
         """
         device = self.__hyperedge_index.device
         num_hyperedges = num_hyperedges if num_hyperedges is not None else self.num_hyperedges
@@ -687,7 +687,7 @@ class HyperedgeIndex:
             num_hyperedges: Total number of hyperedges. If ``None``, inferred from hyperedge index.
 
         Returns:
-            The sparse HGNN Laplacian matrix of shape ``(num_nodes, num_nodes)``.
+            laplacian: The sparse HGNN Laplacian matrix of shape ``(num_nodes, num_nodes)``.
         """
         num_nodes = num_nodes if num_nodes is not None else self.num_nodes
         num_hyperedges = num_hyperedges if num_hyperedges is not None else self.num_hyperedges
@@ -733,7 +733,7 @@ class HyperedgeIndex:
             num_hyperedges: Total number of hyperedges. If ``None``, inferred from hyperedge index.
 
         Returns:
-            The sparse HGNN+ smoothing matrix of shape ``(num_nodes, num_nodes)``.
+            laplacian: The sparse HGNN+ smoothing matrix of shape ``(num_nodes, num_nodes)``.
         """
         num_nodes = num_nodes if num_nodes is not None else self.num_nodes
         num_hyperedges = num_hyperedges if num_hyperedges is not None else self.num_hyperedges
@@ -766,7 +766,7 @@ class HyperedgeIndex:
             **kwargs: Additional keyword arguments for specific strategies.
 
         Returns:
-            The edge index of the reduced graph. Size ``(2, num_edges)``.
+            edge_index: The edge index of the reduced graph. Size ``(2, num_edges)``.
         """
         match strategy:
             case _:
@@ -782,7 +782,7 @@ class HyperedgeIndex:
         the sparse incidence matrix of shape ``[num_nodes, num_hyperedges]`` and ``A`` is the adjacency matrix of the clique-expanded graph.
 
         Returns:
-            The edge index of the clique-expanded graph. Size ``(2, |E'|)``.
+            edge_index: The edge index of the clique-expanded graph. Size ``(2, |E'|)``.
         """
         incidence_matrix = self.get_sparse_incidence_matrix()
 
@@ -827,7 +827,7 @@ class HyperedgeIndex:
             return_weights: Whether to return the DHG-style reduced-edge weights alongside the edge index. Defaults to ``False``.
 
         Returns:
-            A tuple ``(edge_index, edge_weights)`` where:
+            reduced_graph: A tuple ``(edge_index, edge_weights)`` where:
             - ``edge_index`` has size ``(2, |num_edges|)``.
             - ``edge_weights`` has size ``(|num_edges|,)`` when ``return_weights=True``, otherwise ``None``.
 
@@ -923,7 +923,7 @@ class HyperedgeIndex:
             k: The minimum number of nodes a hyperedge must contain to be kept.
 
         Returns:
-            A new :class:`HyperedgeIndex` instance with hyperedges containing fewer than k nodes.
+            hyperedge_index: A new :class:`HyperedgeIndex` instance with hyperedges containing fewer than k nodes.
         """
         _, idx_to_hyperedge_id, num_nodes_per_hyperedge = torch.unique(
             self.all_hyperedge_ids,
@@ -949,7 +949,7 @@ class HyperedgeIndex:
                 If ``None``, all hyperedge IDs in the hyperedge index will be rebased to 0-based format based on their unique sorted order.
 
         Returns:
-            A new :class:`HyperedgeIndex` instance with the hyperedge index converted to 0-based format.
+            hyperedge_index: A new :class:`HyperedgeIndex` instance with the hyperedge index converted to 0-based format.
         """
         # Example: hyperedge_index after sorting: [[0, 0, 1, 2, 3, 4],
         #                                          [3, 4, 4, 3, 4, 3]]

--- a/hyperbench/utils/data_utils.py
+++ b/hyperbench/utils/data_utils.py
@@ -39,7 +39,7 @@ def to_0based_ids(original_ids: Tensor, ids_to_rebase: Tensor | None = None) -> 
         ids_to_rebase: Optional tensor of IDs to keep and remap. If None, all unique IDs are used.
 
     Returns:
-        Tensor of 0-based IDs.
+        ids: Tensor of 0-based IDs.
     """
     if ids_to_rebase is None:
         sorted_unique_original_ids = original_ids.unique(sorted=True)

--- a/hyperbench/utils/file_utils.py
+++ b/hyperbench/utils/file_utils.py
@@ -9,7 +9,7 @@ def decompress_zst(zst_path: str) -> str:
     Args:
         zst_path: The path to the .zst file to decompress.
     Returns:
-        The path to the decompressed JSON file.
+        path: The path to the decompressed JSON file.
     """
     dctx = zstd.ZstdDecompressor()
     with (
@@ -28,7 +28,7 @@ def compress_to_zst(json_path: str) -> bytes:
     Args:
         json_path: The path to the JSON file to compress.
     Returns:
-        The compressed content as bytes.
+        content: The compressed content as bytes.
     """
     cctx = zstd.ZstdCompressor()
     with open(json_path, "rb") as input_f:

--- a/hyperbench/utils/hif_utils.py
+++ b/hyperbench/utils/hif_utils.py
@@ -18,7 +18,7 @@ def validate_hif_json(filename: str) -> bool:
         filename: Path to the JSON file to validate.
 
     Returns:
-        ``True`` if the file is valid HIF, ``False`` otherwise.
+        valid: ``True`` if the file is valid HIF, ``False`` otherwise.
     """
     url = f"https://raw.githubusercontent.com/HIF-org/HIF-standard/{HIF_SCHEMA_COMMIT_SHA}/schemas/hif_schema.json"
     try:

--- a/hyperbench/utils/nn_utils.py
+++ b/hyperbench/utils/nn_utils.py
@@ -43,7 +43,7 @@ def maxmin_scatter(
             If not provided, it will be inferred from the maximum index value.
 
     Returns:
-        A tensor containing the max-min values for each index group.
+        values: A tensor containing the max-min values for each index group.
     """
     max_embeddings = scatter(src=src, index=index, dim=dim, dim_size=dim_size, reduce="max")
     min_embeddings = scatter(src=src, index=index, dim=dim, dim_size=dim_size, reduce="min")

--- a/hyperbench/utils/random_utils.py
+++ b/hyperbench/utils/random_utils.py
@@ -15,7 +15,7 @@ def create_seeded_torch_generator(
         seed: Optional seed for deterministic random operations.
 
     Returns:
-        A seeded torch.Generator when ``seed`` is provided, otherwise ``None``.
+        generator: A seeded torch.Generator when ``seed`` is provided, otherwise ``None``.
     """
     if seed is None:
         return None

--- a/hyperbench/utils/sparse_utils.py
+++ b/hyperbench/utils/sparse_utils.py
@@ -19,7 +19,7 @@ def sparse_dropout(
         fill_value: The fill value for dropped elements. Defaults to ``0.0``.
 
     Returns:
-        A new sparse matrix with the same shape as the input sparse matrix, but with some elements dropped out.
+        matrix: A new sparse matrix with the same shape as the input sparse matrix, but with some elements dropped out.
     """
     device = sparse_tensor.device
 


### PR DESCRIPTION
## Summary
- Add explicit output names to `Returns:` entries across hyperbench docstrings.
- Keep the change limited to documentation metadata for generated docs.

## Why
Fixes #219. Generated documentation requires named return outputs so return tables render consistent output names.

## Changes
- Added semantic return names such as `hdata`, `dataset`, `loss`, `scores`, `node_features`, and related tensor names.
- Left runtime code, schema, examples, and tests unchanged.

## Testing
- Checked all `hyperbench/` Python docstring `Returns:` entries: `UNNAMED 0`
- Ran `git diff --check`

## Known Issues
- Full Python validation was not run locally because `python`/`uv` were unavailable in this environment.
