### PR TITLE
Fix transductive split

### DIFF
--- a/docs/user-guide/training.md
+++ b/docs/user-guide/training.md
@@ -88,6 +88,9 @@ with MultiModelTrainer(
     trainer.test_all(dataloader=test_loader)
 ```
 
+Transductive splits may move hyperedges into the first split to cover every node.
+Use `split_with_ratios(...)` instead of `split(...)` when you need the final hyperedge ratios after that rebalancing.
+
 ## Next steps
 
 - Comparing multiple models consistently: [Benchmarking](benchmarking.md).

--- a/hyperbench/data/__init__.py
+++ b/hyperbench/data/__init__.py
@@ -37,6 +37,8 @@ from .sampling import (
     create_sampler_from_strategy,
 )
 
+from .splitter import HyperedgeIDSplitter, Splitter
+
 __all__ = [
     "AlgebraDataset",
     "AmazonDataset",
@@ -54,6 +56,7 @@ __all__ = [
     "GeometryDataset",
     "HIFLoader",
     "HIFProcessor",
+    "HyperedgeIDSplitter",
     "HyperedgeSampler",
     "IMDBDataset",
     "MusicBluesReviewsDataset",
@@ -65,6 +68,7 @@ __all__ = [
     "PubmedDataset",
     "RestaurantReviewsDataset",
     "SamplingStrategy",
+    "Splitter",
     "ThreadsAskUbuntuDataset",
     "ThreadsMathsxDataset",
     "TwitterDataset",

--- a/hyperbench/data/dataset.py
+++ b/hyperbench/data/dataset.py
@@ -6,15 +6,14 @@ from torch.utils.data import Dataset as TorchDataset
 from hyperbench.nn import EnrichmentMode, NodeEnricher, HyperedgeEnricher
 from hyperbench.types import HData
 from hyperbench.utils import (
-    NodeSpaceAssignment,
     NodeSpaceFiller,
     NodeSpaceSetting,
-    is_inductive_setting,
-    is_transductive_split,
+    is_transductive_setting,
 )
 
-from hyperbench.data.sampling import SamplingStrategy, create_sampler_from_strategy
 from hyperbench.data.hif import HIFLoader, HIFProcessor
+from hyperbench.data.sampling import SamplingStrategy, create_sampler_from_strategy
+from hyperbench.data.splitter import HyperedgeIDSplitter
 
 if TYPE_CHECKING:
     from hyperbench.train import NegativeSampler
@@ -260,34 +259,27 @@ class Dataset(TorchDataset):
         shuffle: bool | None = False,
         seed: int | None = None,
         node_space_setting: NodeSpaceSetting = "transductive",
-        assign_node_space_to: NodeSpaceAssignment | None = "first",
     ) -> list["Dataset"]:
         """
         Split the dataset by hyperedges into partitions with contiguous 0-based hyperedge IDs.
 
         Boundaries are computed using cumulative floor to prevent early splits from
-        over-consuming edges. The last split absorbs any rounding remainder.
+        over-consuming edges. The last split absorbs any rounding remainder. In the
+        transductive setting, the first split is rebalanced with real hyperedges
+        from later splits when needed to cover the full node space. Splits that
+        would end with zero hyperedges are rejected. Use
+        :meth:`split_with_ratios` to get the final ratios after splitting.
 
         Examples:
-            Transductive split keeping the full node space only on the first split (default):
+            Transductive split keeping and covering the full node space on the first split:
             >>> train, test = dataset.split([0.8, 0.2])
             >>> train.hdata.num_nodes == dataset.hdata.num_nodes
             >>> test.hdata.num_nodes <= dataset.hdata.num_nodes
-
-            Transductive split keeping the full node space on all splits:
-            >>> train, test = dataset.split(
-            ...     [0.8, 0.2],
-            ...     node_space_setting="transductive",
-            ...     assign_node_space_to="all",
-            ... )
-            >>> train.hdata.num_nodes == dataset.hdata.num_nodes
-            >>> test.hdata.num_nodes == dataset.hdata.num_nodes
 
             Inductive split:
             >>> train, test = dataset.split(
             ...     [0.8, 0.2],
             ...     node_space_setting="inductive",
-            ...     assign_node_space_to=None,
             ... )
             >>> train.hdata.num_nodes <= dataset.hdata.num_nodes
             >>> test.hdata.num_nodes <= dataset.hdata.num_nodes
@@ -297,14 +289,59 @@ class Dataset(TorchDataset):
             shuffle: Whether to shuffle hyperedges before splitting. Defaults to ``False`` for deterministic splits.
             seed: Optional random seed for reproducibility. Ignored if shuffle is set to ``False``.
             node_space_setting: Whether to preserve the full node space in the splits.
-                ``transductive`` (default) ensures all nodes are present in every split,
-                while ``inductive`` allows splits to have disjoint node spaces.
-            assign_node_space_to: Which split(s) preserve the full node space when
-                ``node_space_setting="transductive"``.
-                ``first`` preserves only the first returned split. ``all`` preserves all splits.
+                ``transductive`` (default) preserves the full node space on the
+                first split and ensures every node is incident to one of its
+                selected hyperedges. ``inductive`` keeps each split's local node
+                space. Ratios are approximate when transductive coverage requires
+                moving hyperedges into the first split.
 
         Returns:
             datasets: List of Dataset objects, one per split, each with contiguous IDs.
+
+        Raises:
+            ValueError: If ratios do not sum to ``1.0``, a final split has zero
+                hyperedges, or a transductive first split cannot cover the full
+                node space.
+        """
+        split_datasets, _ = self.split_with_ratios(
+            ratios=ratios,
+            shuffle=shuffle,
+            seed=seed,
+            node_space_setting=node_space_setting,
+        )
+        return split_datasets
+
+    def split_with_ratios(
+        self,
+        ratios: list[float],
+        shuffle: bool | None = False,
+        seed: int | None = None,
+        node_space_setting: NodeSpaceSetting = "transductive",
+    ) -> tuple[list["Dataset"], list[float]]:
+        """Split the dataset and return the final hyperedge ratios.
+
+        Final ratios are computed from split hyperedge counts after ratio
+        boundaries and any transductive rebalancing have been applied.
+
+        Args:
+            ratios: List of floats summing to ``1.0``, e.g., ``[0.8, 0.1, 0.1]``.
+            shuffle: Whether to shuffle hyperedges before splitting. Defaults to
+                ``False`` for deterministic splits.
+            seed: Optional random seed for reproducibility. Ignored if ``shuffle``
+                is set to ``False``.
+            node_space_setting: Whether to preserve the full node space in the
+                splits. ``transductive`` (default) preserves the full node space
+                on the first split and may move hyperedges from later splits to
+                cover all nodes. ``inductive`` keeps each split's local node space.
+
+        Returns:
+            datasets_and_ratios: A tuple containing the split datasets and their
+                final hyperedge-count ratios.
+
+        Raises:
+            ValueError: If ratios do not sum to ``1.0``, a final split has zero
+                hyperedges, or a transductive first split cannot cover the full
+                node space.
         """
         # Allow small imprecision in sum of ratios, but raise error if it's significant
         # Example: ratios = [0.8, 0.1, 0.1] -> sum = 1.0 (valid)
@@ -312,54 +349,31 @@ class Dataset(TorchDataset):
         #          ratios = [0.8, 0.1, 0.1, 0.0000001] -> sum = 1.0000001 (valid, allows small imprecision)
         if abs(sum(ratios) - 1.0) > 1e-6:
             raise ValueError(f"Split ratios must sum to 1.0, got {sum(ratios)}.")
-        if is_inductive_setting(node_space_setting) and assign_node_space_to is not None:
-            raise ValueError(
-                "assign_node_space_to can only be provided when node_space_setting='transductive'."
-            )
-
         device = self.hdata.device
-        num_hyperedges = self.hdata.num_hyperedges
-        hyperedge_ids_permutation = self.__get_hyperedge_ids_permutation(
-            num_hyperedges, shuffle, seed
-        )
 
-        # Compute cumulative ratio boundaries to avoid independent rounding errors.
-        # Independent rounding (e.g., round(0.5*3)=2, round(0.25*3)=1, round(0.25*3)=1 -> total=4)
-        # can over-allocate edges to early splits and starve later ones.
-        # Cumulative floor boundaries guarantee monotonically increasing cut points.
-        # Example: ratios = [0.5, 0.25, 0.25], num_hyperedges = 3
-        #          cumulative_ratios = [0.5, 0.75, 1.0]
-        cumulative_ratios = []
-        cumsum = 0.0
-        for ratio in ratios:
-            cumsum += ratio
-            cumulative_ratios.append(cumsum)
+        hyperedge_splitter = HyperedgeIDSplitter(self.hdata)
+        hyperedge_ids_permutation = hyperedge_splitter.get_hyperedge_ids_permutation(shuffle, seed)
+        hyperedge_ids_by_split, final_ratios = hyperedge_splitter.split(
+            hyperedge_ids_permutation, ratios
+        )
+        if is_transductive_setting(node_space_setting):
+            hyperedge_ids_by_split, final_ratios = hyperedge_splitter.ensure_split_covers_all_nodes(
+                hyperedge_ids_by_split=hyperedge_ids_by_split,
+                split_idx=0,
+            )
+        hyperedge_splitter.validate_splits_have_hyperedges(hyperedge_ids_by_split)
 
         split_datasets = []
-        start = 0
-        for i in range(len(ratios)):
-            if i == len(ratios) - 1:
-                # Last split gets everything remaining, absorbing any rounding remainder
-                # Example: start = 2, end = 3 -> permutation[2:3] = [2] (1 edge)
-                end = num_hyperedges
-            else:
-                # Floor of cumulative boundary ensures early splits don't over-consume
-                # Example: i=0 -> int(0.5 * 3) = int(1.5) = 1, end = 1
-                #          i=1 -> int(0.75 * 3) = int(2.25) = 2, end = 2
-                end = int(cumulative_ratios[i] * num_hyperedges)
-
-            # Example: i=0 -> permutation[0:1] = [0] (1 edge)
-            #          i=1 -> permutation[1:2] = [1] (1 edge)
-            #          i=2 -> permutation[2:3] = [2] (1 edge)
-            split_hyperedge_ids = hyperedge_ids_permutation[start:end]
-
-            use_transductive_node_space = is_transductive_split(
-                node_space_setting, assign_node_space_to, split_num=i
+        for split_num, split_hyperedge_ids in enumerate(hyperedge_ids_by_split):
+            split_node_space_setting: NodeSpaceSetting = (
+                "transductive"
+                if is_transductive_setting(node_space_setting) and split_num == 0
+                else "inductive"
             )
             split_hdata = HData.split(
-                self.hdata,
-                split_hyperedge_ids,
-                node_space_setting="transductive" if use_transductive_node_space else "inductive",
+                hdata=self.hdata,
+                split_hyperedge_ids=split_hyperedge_ids,
+                node_space_setting=split_node_space_setting,
             ).to(device=device)
 
             split_dataset = self.__class__(
@@ -368,9 +382,7 @@ class Dataset(TorchDataset):
             )
             split_datasets.append(split_dataset)
 
-            start = end
-
-        return split_datasets
+        return split_datasets, final_ratios
 
     def to(self, device: torch.device) -> "Dataset":
         """
@@ -426,27 +438,3 @@ class Dataset(TorchDataset):
         """
 
         return self.hdata.stats()
-
-    def __get_hyperedge_ids_permutation(
-        self,
-        num_hyperedges: int,
-        shuffle: bool | None,
-        seed: int | None,
-    ) -> Tensor:
-        device = self.hdata.device
-
-        # Shuffle hyperedge IDs if shuffle is requested, otherwise keep original order for deterministic splits
-        if shuffle:
-            generator = torch.Generator(device=device)
-            if seed is not None:
-                generator.manual_seed(seed)
-
-            random_hyperedge_ids_permutation = torch.randperm(
-                n=num_hyperedges,
-                generator=generator,
-                device=device,
-            )
-            return random_hyperedge_ids_permutation
-
-        ranged_hyperedge_ids_permutation = torch.arange(num_hyperedges, device=device)
-        return ranged_hyperedge_ids_permutation

--- a/hyperbench/data/dataset.py
+++ b/hyperbench/data/dataset.py
@@ -266,9 +266,9 @@ class Dataset(TorchDataset):
         Boundaries are computed using cumulative floor to prevent early splits from
         over-consuming edges. The last split absorbs any rounding remainder. In the
         transductive setting, the first split is rebalanced with real hyperedges
-        from later splits when needed to cover the full node space. Splits that
-        would end with zero hyperedges are rejected. Use
-        :meth:`split_with_ratios` to get the final ratios after splitting.
+        from later splits when needed to cover the full node space.
+        Splits that would end with zero hyperedges are rejected.
+        Use ``split_with_ratios`` to get the final ratios after splitting.
 
         Examples:
             Transductive split keeping and covering the full node space on the first split:

--- a/hyperbench/data/splitter.py
+++ b/hyperbench/data/splitter.py
@@ -1,0 +1,172 @@
+import torch
+
+from abc import ABC, abstractmethod
+from typing import cast
+from torch import Tensor
+from hyperbench.types import HData
+
+
+class Splitter(ABC):
+    @abstractmethod
+    def split(self, to_split: Tensor, ratios: list[float]) -> tuple[list[Tensor], list[float]]:
+        """
+        Split the input tensor into multiple tensors according to the provided ratios.
+        The output tensors are not guaranteed to be non-empty, so downstream validation may be necessary.
+
+        Args:
+            to_split: The tensor to split. For example, a list of hyperedge IDs.
+            ratios: The ratios for the splits. For example, ``[0.7, 0.1, 0.2]`` for a 70/10/20 split.
+
+        Returns:
+            (Values per split, ratios after splitting): A tuple of (list of split tensors, list of actual ratios achieved by the splits).
+        """
+        pass
+
+
+class HyperedgeIDSplitter(Splitter):
+    def __init__(self, hdata: HData) -> None:
+        self.hdata = hdata
+
+    def ensure_split_covers_all_nodes(
+        self,
+        hyperedge_ids_by_split: list[Tensor],
+        split_idx: int = 0,
+    ) -> tuple[list[Tensor], list[float]]:
+        required_node_ids = torch.arange(self.hdata.num_nodes, device=self.hdata.device)
+        available_node_ids = self.hdata.hyperedge_index[0].unique()
+        missing_from_hypergraph_mask = torch.logical_not(
+            torch.isin(required_node_ids, available_node_ids)
+        )
+        if bool(missing_from_hypergraph_mask.any()):
+            missing_node_ids = required_node_ids[missing_from_hypergraph_mask].tolist()
+            raise ValueError(
+                "Cannot create a transductive first split covering all nodes because "
+                f"these node ids do not appear in any hyperedge: {missing_node_ids}."
+            )
+
+        missing_node_ids = self.__missing_node_ids(
+            hyperedge_ids=hyperedge_ids_by_split[split_idx],
+            required_node_ids=required_node_ids,
+        )
+        while missing_node_ids.numel() > 0:
+            donor_split_idx, hyperedge_id = self.__pick_covering_hyperedge(
+                hyperedge_ids_by_split=hyperedge_ids_by_split,
+                missing_node_ids=missing_node_ids,
+            )
+            hyperedge_ids_by_split[split_idx] = torch.cat(
+                [hyperedge_ids_by_split[split_idx], hyperedge_id.view(1)]
+            )
+            donor_hyperedge_ids = hyperedge_ids_by_split[donor_split_idx]
+            hyperedge_ids_by_split[donor_split_idx] = donor_hyperedge_ids[
+                donor_hyperedge_ids != hyperedge_id
+            ]
+            missing_node_ids = self.__missing_node_ids(
+                hyperedge_ids=hyperedge_ids_by_split[split_idx],
+                required_node_ids=required_node_ids,
+            )
+
+        return hyperedge_ids_by_split, self.get_split_ratios(hyperedge_ids_by_split)
+
+    def validate_splits_have_hyperedges(self, hyperedge_ids_by_split: list[Tensor]) -> None:
+        empty_split_indices = [
+            split_idx
+            for split_idx, split_hyperedge_ids in enumerate(hyperedge_ids_by_split)
+            if split_hyperedge_ids.numel() == 0
+        ]
+        if empty_split_indices:
+            final_ratios = self.get_split_ratios(hyperedge_ids_by_split)
+            raise ValueError(
+                f"Cannot create dataset splits because splits {empty_split_indices} "
+                f"contain no hyperedges. Final ratios: {final_ratios}."
+            )
+
+    def get_hyperedge_ids_permutation(self, shuffle: bool | None, seed: int | None) -> Tensor:
+        device = self.hdata.device
+        num_hyperedges = self.hdata.num_hyperedges
+
+        # Shuffle hyperedge IDs if shuffle is requested, otherwise keep original order for deterministic splits
+        if shuffle:
+            generator = torch.Generator(device=device)
+            if seed is not None:
+                generator.manual_seed(seed)
+
+            random_hyperedge_ids_permutation = torch.randperm(
+                n=num_hyperedges,
+                generator=generator,
+                device=device,
+            )
+            return random_hyperedge_ids_permutation
+
+        ranged_hyperedge_ids_permutation = torch.arange(num_hyperedges, device=device)
+        return ranged_hyperedge_ids_permutation
+
+    def get_split_ratios(self, hyperedge_ids_by_split: list[Tensor]) -> list[float]:
+        num_hyperedges_by_split = [
+            int(split_hyperedge_ids.numel()) for split_hyperedge_ids in hyperedge_ids_by_split
+        ]
+        num_hyperedges = sum(num_hyperedges_by_split)
+        if num_hyperedges == 0:
+            return [0.0 for _ in hyperedge_ids_by_split]
+
+        return [
+            round(split_num_hyperedges / num_hyperedges, 4)
+            for split_num_hyperedges in num_hyperedges_by_split
+        ]
+
+    def split(self, to_split: Tensor, ratios: list[float]) -> tuple[list[Tensor], list[float]]:
+        # Cumulative floor boundaries keep early splits from over-consuming hyperedges.
+        # The last split absorbs any rounding remainder.
+        num_hyperedges = int(to_split.size(0))
+
+        start = 0
+        cumulative_ratio = 0.0
+        hyperedge_ids_by_split = []
+        for split_idx, ratio in enumerate(ratios):
+            cumulative_ratio += ratio
+            end = (
+                num_hyperedges
+                if split_idx == len(ratios) - 1
+                else int(cumulative_ratio * num_hyperedges)
+            )
+            hyperedge_ids_by_split.append(to_split[start:end])
+            start = end
+
+        return hyperedge_ids_by_split, self.get_split_ratios(hyperedge_ids_by_split)
+
+    def __missing_node_ids(self, hyperedge_ids: Tensor, required_node_ids: Tensor) -> Tensor:
+        covered_node_ids = self.__nodes_covered_by_hyperedges(hyperedge_ids)
+        covered_node_ids_mask = torch.isin(required_node_ids, covered_node_ids)
+        not_covered_node_ids_mask = torch.logical_not(covered_node_ids_mask)
+        return required_node_ids[not_covered_node_ids_mask]
+
+    def __nodes_covered_by_hyperedges(self, hyperedge_ids: Tensor) -> Tensor:
+        all_hyperedge_ids = self.hdata.hyperedge_index[1]
+        nodes_in_input_hyperedges_mask = torch.isin(all_hyperedge_ids, hyperedge_ids)
+        all_node_ids = self.hdata.hyperedge_index[0]
+        return all_node_ids[nodes_in_input_hyperedges_mask].unique()
+
+    def __pick_covering_hyperedge(
+        self,
+        hyperedge_ids_by_split: list[Tensor],
+        missing_node_ids: Tensor,
+    ) -> tuple[int, Tensor]:
+        best_gain = 0
+        best_split_idx: int | None = None
+        best_hyperedge_id: Tensor | None = None
+
+        for split_idx, split_hyperedge_ids in enumerate(
+            hyperedge_ids_by_split[1:],
+            start=1,
+        ):
+            for hyperedge_id in split_hyperedge_ids:
+                covered_node_ids = self.__nodes_covered_by_hyperedges(hyperedge_id.view(1))
+                missing_nodes_in_covered_nodes_mask = torch.isin(covered_node_ids, missing_node_ids)
+                gain = int(missing_nodes_in_covered_nodes_mask.sum().item())
+                if gain > best_gain:
+                    best_split_idx = split_idx
+                    best_hyperedge_id = hyperedge_id
+                    best_gain = gain
+
+        # Split construction partitions every available hyperedge, so
+        # a valid HData has a covering donor whenever the first split still misses a node
+        return cast(int, best_split_idx), cast(Tensor, best_hyperedge_id)

--- a/hyperbench/data/splitter.py
+++ b/hyperbench/data/splitter.py
@@ -7,6 +7,10 @@ from hyperbench.types import HData
 
 
 class Splitter(ABC):
+    """
+    Abstract base class for splitters.
+    """
+
     @abstractmethod
     def split(self, to_split: Tensor, ratios: list[float]) -> tuple[list[Tensor], list[float]]:
         """
@@ -24,6 +28,13 @@ class Splitter(ABC):
 
 
 class HyperedgeIDSplitter(Splitter):
+    """
+    Initialize a splitter for hyperedge-ID based dataset partitioning.
+
+    Args:
+        hdata: Hypergraph data whose hyperedges and node coverage drive the split logic.
+    """
+
     def __init__(self, hdata: HData) -> None:
         self.hdata = hdata
 
@@ -32,6 +43,23 @@ class HyperedgeIDSplitter(Splitter):
         hyperedge_ids_by_split: list[Tensor],
         split_idx: int = 0,
     ) -> tuple[list[Tensor], list[float]]:
+        """
+        Rebalance a split until its hyperedges cover every node in the hypergraph.
+
+        Hyperedges are moved from the other splits into the target split, always
+        choosing the donor hyperedge that covers the largest number of currently missing nodes.
+
+        Args:
+            hyperedge_ids_by_split: Hyperedge IDs assigned to each split.
+            split_idx: Index of the split that must cover the full node space.
+
+        Returns:
+            hyperedge_ids_by_split: The updated hyperedge IDs for each split.
+            ratios: The final ratios of hyperedges in each split after rebalancing.
+
+        Raises:
+            ValueError: If one or more nodes do not appear in any hyperedge of the source hypergraph.
+        """
         required_node_ids = torch.arange(self.hdata.num_nodes, device=self.hdata.device)
         available_node_ids = self.hdata.hyperedge_index[0].unique()
         missing_from_hypergraph_mask = torch.logical_not(
@@ -52,6 +80,7 @@ class HyperedgeIDSplitter(Splitter):
             donor_split_idx, hyperedge_id = self.__pick_covering_hyperedge(
                 hyperedge_ids_by_split=hyperedge_ids_by_split,
                 missing_node_ids=missing_node_ids,
+                split_to_cover_idx=split_idx,
             )
             hyperedge_ids_by_split[split_idx] = torch.cat(
                 [hyperedge_ids_by_split[split_idx], hyperedge_id.view(1)]
@@ -68,6 +97,15 @@ class HyperedgeIDSplitter(Splitter):
         return hyperedge_ids_by_split, self.get_split_ratios(hyperedge_ids_by_split)
 
     def validate_splits_have_hyperedges(self, hyperedge_ids_by_split: list[Tensor]) -> None:
+        """
+        Validate that every split retains at least one hyperedge.
+
+        Args:
+            hyperedge_ids_by_split: Hyperedge IDs assigned to each split.
+
+        Raises:
+            ValueError: If any split is empty after splitting or rebalancing.
+        """
         empty_split_indices = [
             split_idx
             for split_idx, split_hyperedge_ids in enumerate(hyperedge_ids_by_split)
@@ -81,6 +119,16 @@ class HyperedgeIDSplitter(Splitter):
             )
 
     def get_hyperedge_ids_permutation(self, shuffle: bool | None, seed: int | None) -> Tensor:
+        """
+        Return hyperedge IDs in deterministic or shuffled order.
+
+        Args:
+            shuffle: Whether to randomly permute the hyperedge IDs.
+            seed: Optional random seed used when ``shuffle`` is truthy.
+
+        Returns:
+            hyperedge_ids_permutation: Ordered or shuffled hyperedge IDs on the HData device.
+        """
         device = self.hdata.device
         num_hyperedges = self.hdata.num_hyperedges
 
@@ -101,6 +149,15 @@ class HyperedgeIDSplitter(Splitter):
         return ranged_hyperedge_ids_permutation
 
     def get_split_ratios(self, hyperedge_ids_by_split: list[Tensor]) -> list[float]:
+        """
+        Compute realized split ratios from hyperedge counts.
+
+        Args:
+            hyperedge_ids_by_split: Hyperedge IDs assigned to each split.
+
+        Returns:
+            ratios: Ratios derived from the number of hyperedges in each split.
+        """
         num_hyperedges_by_split = [
             int(split_hyperedge_ids.numel()) for split_hyperedge_ids in hyperedge_ids_by_split
         ]
@@ -114,6 +171,20 @@ class HyperedgeIDSplitter(Splitter):
         ]
 
     def split(self, to_split: Tensor, ratios: list[float]) -> tuple[list[Tensor], list[float]]:
+        """
+        Split hyperedge IDs by cumulative ratio boundaries.
+
+        Early splits use cumulative floor boundaries to avoid over-consuming hyperedges.
+        The final split receives any remaining hyperedges caused by rounding.
+
+        Args:
+            to_split: Hyperedge IDs to partition.
+            ratios: Requested split ratios.
+
+        Returns:
+            hyperedge_ids_by_split: The updated hyperedge IDs for each split.
+            ratios: The final ratios of hyperedges in each split after rebalancing.
+        """
         # Cumulative floor boundaries keep early splits from over-consuming hyperedges.
         # The last split absorbs any rounding remainder.
         num_hyperedges = int(to_split.size(0))
@@ -134,12 +205,31 @@ class HyperedgeIDSplitter(Splitter):
         return hyperedge_ids_by_split, self.get_split_ratios(hyperedge_ids_by_split)
 
     def __missing_node_ids(self, hyperedge_ids: Tensor, required_node_ids: Tensor) -> Tensor:
+        """
+        Return the node IDs not covered by the given hyperedges.
+
+        Args:
+            hyperedge_ids: Hyperedge IDs whose node coverage should be inspected.
+            required_node_ids: Node IDs that must be covered.
+
+        Returns:
+            missing_node_ids: Required node IDs that are still uncovered.
+        """
         covered_node_ids = self.__nodes_covered_by_hyperedges(hyperedge_ids)
         covered_node_ids_mask = torch.isin(required_node_ids, covered_node_ids)
         not_covered_node_ids_mask = torch.logical_not(covered_node_ids_mask)
         return required_node_ids[not_covered_node_ids_mask]
 
     def __nodes_covered_by_hyperedges(self, hyperedge_ids: Tensor) -> Tensor:
+        """
+        Collect unique node IDs incident to the provided hyperedges.
+
+        Args:
+            hyperedge_ids: Hyperedge IDs to inspect.
+
+        Returns:
+            nodes_covered_by_hyperedge: Unique node IDs covered by the input hyperedges.
+        """
         all_hyperedge_ids = self.hdata.hyperedge_index[1]
         nodes_in_input_hyperedges_mask = torch.isin(all_hyperedge_ids, hyperedge_ids)
         all_node_ids = self.hdata.hyperedge_index[0]
@@ -149,15 +239,27 @@ class HyperedgeIDSplitter(Splitter):
         self,
         hyperedge_ids_by_split: list[Tensor],
         missing_node_ids: Tensor,
+        split_to_cover_idx: int,
     ) -> tuple[int, Tensor]:
+        """
+        Choose the donor hyperedge that covers the most currently missing nodes.
+
+        Args:
+            hyperedge_ids_by_split: Hyperedge IDs assigned to each split.
+            missing_node_ids: Node IDs still missing from the target split.
+            split_to_cover_idx: Index of the split being rebalanced.
+
+        Returns:
+            split_idx: The index of the donor split containing the selected hyperedge.
+            hyperedge_id: The ID of the selected hyperedge.
+        """
         best_gain = 0
         best_split_idx: int | None = None
         best_hyperedge_id: Tensor | None = None
+        for split_idx, split_hyperedge_ids in enumerate(hyperedge_ids_by_split):
+            if split_idx == split_to_cover_idx:
+                continue
 
-        for split_idx, split_hyperedge_ids in enumerate(
-            hyperedge_ids_by_split[1:],
-            start=1,
-        ):
             for hyperedge_id in split_hyperedge_ids:
                 covered_node_ids = self.__nodes_covered_by_hyperedges(hyperedge_id.view(1))
                 missing_nodes_in_covered_nodes_mask = torch.isin(covered_node_ids, missing_node_ids)

--- a/hyperbench/nn/enricher.py
+++ b/hyperbench/nn/enricher.py
@@ -323,7 +323,10 @@ class Node2VecEnricher(NodeEnricher):
             )
             return torch.empty((0, self.embedding_dim), device=device)
 
-        reduced_edge_index = hyperedge_index_wrapper.reduce(self.graph_reduction_strategy)
+        reduced_edge_index = hyperedge_index_wrapper.reduce(
+            self.graph_reduction_strategy,
+            num_nodes=num_nodes,
+        )
         edge_index_wrapper = EdgeIndex(reduced_edge_index).remove_selfloops()
         if edge_index_wrapper.num_edges == 0:
             warnings.warn(
@@ -420,9 +423,11 @@ class LaplacianPositionalEncodingEnricher(NodeEnricher):
         Returns:
             node_features: Tensor of shape ``(num_nodes, num_features)``.
         """
-        edge_index = HyperedgeIndex(hyperedge_index).reduce_to_edge_index_on_clique_expansion()
-        edge_index_wrapper = EdgeIndex(edge_index)
         num_nodes = self.num_nodes if self.num_nodes > 0 else None
+        edge_index = HyperedgeIndex(hyperedge_index).reduce_to_edge_index_on_clique_expansion(
+            num_nodes=num_nodes
+        )
+        edge_index_wrapper = EdgeIndex(edge_index)
         laplacian_matrix = edge_index_wrapper.get_sparse_normalized_laplacian(num_nodes=num_nodes)
         laplacian_matrix_dense = (
             laplacian_matrix.to_dense()  # torch.linalg.eigh only works on dense tensors

--- a/hyperbench/tests/__init__.py
+++ b/hyperbench/tests/__init__.py
@@ -1,3 +1,13 @@
-from .mock import MOCK_BASE_PATH, new_mock_named_temporary_file, new_mock_trainer
+from .mock import (
+    MOCK_BASE_PATH,
+    new_mock_named_temporary_file,
+    new_mock_trainer,
+    new_mock_negative_sampler,
+)
 
-__all__ = ["MOCK_BASE_PATH", "new_mock_named_temporary_file", "new_mock_trainer"]
+__all__ = [
+    "MOCK_BASE_PATH",
+    "new_mock_named_temporary_file",
+    "new_mock_negative_sampler",
+    "new_mock_trainer",
+]

--- a/hyperbench/tests/data/dataset_test.py
+++ b/hyperbench/tests/data/dataset_test.py
@@ -1,6 +1,6 @@
-import re
 import pytest
 import torch
+import re
 
 from typing import cast
 from unittest.mock import patch, MagicMock
@@ -8,6 +8,7 @@ from hyperbench.data import AlgebraDataset, Dataset, HIFLoader, SamplingStrategy
 from hyperbench.nn import NodeEnricher, HyperedgeEnricher
 from hyperbench.train import NegativeSampler
 from hyperbench.types import HData
+from hyperbench.tests import new_mock_negative_sampler
 
 
 @pytest.fixture
@@ -34,21 +35,14 @@ def mock_hdata_with_hyperedge_weights() -> HData:
 
 
 @pytest.fixture
-def mock_hdata_sample_hypergraph() -> HData:
+def mock_hdata_isolated_hyperedges() -> HData:
     x = torch.ones((2, 1), dtype=torch.float)
     hyperedge_index = torch.tensor([[0, 1], [0, 1]], dtype=torch.long)
     return HData(x=x, hyperedge_index=hyperedge_index)
 
 
 @pytest.fixture
-def mock_hdata_simple_hypergraph() -> HData:
-    x = torch.ones((2, 1), dtype=torch.float)
-    hyperedge_index = torch.tensor([[0, 1], [0, 1]], dtype=torch.long)
-    return HData(x=x, hyperedge_index=hyperedge_index)
-
-
-@pytest.fixture
-def mock_hdata_three_node_weighted_hypergraph() -> HData:
+def mock_hdata_three_nodes_weighted() -> HData:
     x = torch.ones((3, 1), dtype=torch.float)
     hyperedge_index = torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long)
     hyperedge_weights = torch.tensor([[1.0], [2.0]], dtype=torch.float)
@@ -56,21 +50,34 @@ def mock_hdata_three_node_weighted_hypergraph() -> HData:
 
 
 @pytest.fixture
-def mock_hdata_four_node_hypergraph() -> HData:
+def mock_hdata_four_nodes() -> HData:
     x = torch.ones((4, 1), dtype=torch.float)
     hyperedge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long)
     return HData(x=x, hyperedge_index=hyperedge_index)
 
 
 @pytest.fixture
-def mock_hdata_no_edge_attr_hypergraph() -> HData:
+def mock_hdata_transductive_split() -> HData:
+    x = torch.ones((4, 1), dtype=torch.float)
+    hyperedge_index = torch.tensor(
+        [
+            [0, 1, 2, 3, 0, 1, 2, 3],
+            [0, 0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=torch.long,
+    )
+    return HData(x=x, hyperedge_index=hyperedge_index)
+
+
+@pytest.fixture
+def mock_hdata_no_hyperedge_attr() -> HData:
     x = torch.ones((2, 1), dtype=torch.float)
     hyperedge_index = torch.tensor([[0, 1], [0, 0]], dtype=torch.long)
     return HData(x=x, hyperedge_index=hyperedge_index)
 
 
 @pytest.fixture
-def mock_hdata_multiple_edges_attr_hypergraph() -> HData:
+def mock_hdata_multiple_hyperedge_attrs() -> HData:
     x = torch.ones((4, 1), dtype=torch.float)
     hyperedge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 2]], dtype=torch.long)
     hyperedge_weights = torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.float)
@@ -84,14 +91,27 @@ def mock_hdata_multiple_edges_attr_hypergraph() -> HData:
 
 
 @pytest.fixture
-def mock_hdata_no_incidences() -> HData:
-    x = torch.ones((2, 1), dtype=torch.float)
-    hyperedge_index = torch.tensor([[0, 1], [0, 1]], dtype=torch.long)
-    return HData(x=x, hyperedge_index=hyperedge_index)
+def mock_hdata_transductive_multiple_hyperedges_attrs() -> HData:
+    x = torch.ones((4, 1), dtype=torch.float)
+    hyperedge_index = torch.tensor(
+        [
+            [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3],
+            [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2],
+        ],
+        dtype=torch.long,
+    )
+    hyperedge_weights = torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.float)
+    hyperedge_attr = torch.ones((3, 1), dtype=torch.float)
+    return HData(
+        x=x,
+        hyperedge_index=hyperedge_index,
+        hyperedge_weights=hyperedge_weights,
+        hyperedge_attr=hyperedge_attr,
+    )
 
 
 @pytest.fixture
-def mock_hdata_with_two_edge_attributes() -> HData:
+def mock_hdata_two_hyperedge_attrs_weighted() -> HData:
     x = torch.ones((3, 1), dtype=torch.float)
     hyperedge_index = torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long)
     hyperedge_weights = torch.tensor([[1.0, 2.0], [3.0, 0.1]], dtype=torch.float)
@@ -99,33 +119,8 @@ def mock_hdata_with_two_edge_attributes() -> HData:
 
 
 @pytest.fixture
-def mock_hdata_random_ids() -> HData:
-    x = torch.ones((3, 1), dtype=torch.float)
-    hyperedge_index = torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long)
-    return HData(x=x, hyperedge_index=hyperedge_index)
-
-
-@pytest.fixture
 def mock_negative_sampler() -> tuple[NegativeSampler, MagicMock]:
-    def sample(data: HData, seed: int | None = None) -> HData:
-        negative_nodes = torch.tensor([0, 2], dtype=torch.long, device=data.device)
-        negative_hyperedge_id = torch.full(
-            negative_nodes.shape,
-            data.num_hyperedges,
-            dtype=torch.long,
-            device=data.device,
-        )
-        return HData(
-            x=data.x,
-            hyperedge_index=torch.stack([negative_nodes, negative_hyperedge_id]),
-            num_nodes=data.num_nodes,
-            num_hyperedges=1,
-            global_node_ids=data.global_node_ids,
-            y=torch.zeros(1, dtype=torch.float, device=data.device),
-        )
-
-    sampler = MagicMock(spec=NegativeSampler)
-    sampler.sample.side_effect = sample
+    sampler = new_mock_negative_sampler()
     return cast(NegativeSampler, sampler), sampler
 
 
@@ -147,19 +142,17 @@ def test_preloaded_dataset_loads_hdata_when_hdata_is_none():
         pytest.param(SamplingStrategy.HYPEREDGE, 2, id="hyperedge_strategy"),
     ],
 )
-def test_dataset_is_available_with_all_strategies(
-    strategy, expected_len, mock_hdata_four_node_hypergraph
-):
+def test_dataset_is_available_with_all_strategies(strategy, expected_len, mock_hdata_four_nodes):
 
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
         assert dataset.DATASET_NAME == "algebra"
         assert len(dataset) == expected_len
 
 
-def test_dataset_process_no_incidences(mock_hdata_no_incidences):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_no_incidences):
+def test_dataset_process_no_incidences(mock_hdata_isolated_hyperedges):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_isolated_hyperedges):
         dataset = AlgebraDataset()
 
         assert dataset.hdata is not None
@@ -169,8 +162,10 @@ def test_dataset_process_no_incidences(mock_hdata_no_incidences):
         assert dataset.hdata.hyperedge_attr is None
 
 
-def test_dataset_process_with_edge_attributes(mock_hdata_with_two_edge_attributes):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_with_two_edge_attributes):
+def test_dataset_process_with_edge_attributes(mock_hdata_two_hyperedge_attrs_weighted):
+    with patch.object(
+        HIFLoader, "load_by_name", return_value=mock_hdata_two_hyperedge_attrs_weighted
+    ):
         dataset = AlgebraDataset()
 
     assert dataset.hdata is not None
@@ -184,8 +179,8 @@ def test_dataset_process_with_edge_attributes(mock_hdata_with_two_edge_attribute
     assert torch.allclose(dataset.hdata.hyperedge_weights[1], torch.tensor([3.0, 0.1]))
 
 
-def test_dataset_process_without_edge_attributes(mock_hdata_no_edge_attr_hypergraph):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_no_edge_attr_hypergraph):
+def test_dataset_process_without_edge_attributes(mock_hdata_no_hyperedge_attr):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_no_hyperedge_attr):
         dataset = AlgebraDataset()
 
     assert dataset.hdata is not None
@@ -194,23 +189,13 @@ def test_dataset_process_without_edge_attributes(mock_hdata_no_edge_attr_hypergr
     assert dataset.hdata.hyperedge_attr is None
 
 
-def test_dataset_process_hyperedge_index_in_correct_format(mock_hdata_four_node_hypergraph):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+def test_dataset_process_hyperedge_index_in_correct_format(mock_hdata_four_nodes):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset()
 
     assert dataset.hdata.hyperedge_index.shape == (2, 4)
     assert torch.allclose(dataset.hdata.hyperedge_index[0], torch.tensor([0, 1, 2, 3]))
     assert torch.allclose(dataset.hdata.hyperedge_index[1], torch.tensor([0, 0, 1, 1]))
-
-
-def test_dataset_process_random_ids(mock_hdata_random_ids):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_random_ids):
-        dataset = AlgebraDataset()
-
-    assert dataset.hdata.hyperedge_index.shape == (2, 3)
-    assert torch.allclose(dataset.hdata.hyperedge_index[0], torch.tensor([0, 1, 2]))
-    assert torch.allclose(dataset.hdata.hyperedge_index[1], torch.tensor([0, 0, 1]))
-    assert dataset.hdata.hyperedge_attr is None
 
 
 @pytest.mark.parametrize(
@@ -220,8 +205,8 @@ def test_dataset_process_random_ids(mock_hdata_random_ids):
         pytest.param(SamplingStrategy.HYPEREDGE, id="hyperedge_strategy"),
     ],
 )
-def test_getitem_index_list_empty(mock_hdata_simple_hypergraph, strategy):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_simple_hypergraph):
+def test_getitem_index_list_empty(mock_hdata, strategy):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     with pytest.raises(ValueError, match=re.escape("Index list cannot be empty.")):
@@ -246,9 +231,9 @@ def test_getitem_index_list_empty(mock_hdata_simple_hypergraph, strategy):
     ],
 )
 def test_getitem_raises_when_index_list_larger_than_max(
-    mock_hdata_four_node_hypergraph, strategy, index_list, expected_message
+    mock_hdata_four_nodes, strategy, index_list, expected_message
 ):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     with pytest.raises(ValueError, match=expected_message):
@@ -270,9 +255,9 @@ def test_getitem_raises_when_index_list_larger_than_max(
     ],
 )
 def test_getitem_raises_when_index_out_of_bounds(
-    mock_hdata_four_node_hypergraph, strategy, index, expected_message
+    mock_hdata_four_nodes, strategy, index, expected_message
 ):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     with pytest.raises(IndexError, match=expected_message):
@@ -289,9 +274,9 @@ def test_getitem_raises_when_index_out_of_bounds(
     ],
 )
 def test_getitem_single_index(
-    mock_hdata_sample_hypergraph, strategy, index, expected_shape, expected_num_hyperedges
+    mock_hdata_isolated_hyperedges, strategy, index, expected_shape, expected_num_hyperedges
 ):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_sample_hypergraph):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_isolated_hyperedges):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     data = dataset[index]
@@ -310,9 +295,9 @@ def test_getitem_single_index(
     ],
 )
 def test_getitem_when_list_index_provided(
-    mock_hdata_four_node_hypergraph, strategy, index, expected_shape, expected_num_hyperedges
+    mock_hdata_four_nodes, strategy, index, expected_shape, expected_num_hyperedges
 ):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     data = dataset[index]
@@ -328,10 +313,8 @@ def test_getitem_when_list_index_provided(
         pytest.param(SamplingStrategy.HYPEREDGE, id="hyperedge_strategy"),
     ],
 )
-def test_getitem_with_edge_attr(mock_hdata_three_node_weighted_hypergraph, strategy):
-    with patch.object(
-        HIFLoader, "load_by_name", return_value=mock_hdata_three_node_weighted_hypergraph
-    ):
+def test_getitem_with_edge_attr(mock_hdata_three_nodes_weighted, strategy):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_three_nodes_weighted):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     data = dataset[0]
@@ -348,8 +331,8 @@ def test_getitem_with_edge_attr(mock_hdata_three_node_weighted_hypergraph, strat
         pytest.param(SamplingStrategy.HYPEREDGE, id="hyperedge_strategy"),
     ],
 )
-def test_getitem_without_edge_attr(mock_hdata_no_edge_attr_hypergraph, strategy):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_no_edge_attr_hypergraph):
+def test_getitem_without_edge_attr(mock_hdata_no_hyperedge_attr, strategy):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_no_hyperedge_attr):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     data = dataset[0]
@@ -365,12 +348,8 @@ def test_getitem_without_edge_attr(mock_hdata_no_edge_attr_hypergraph, strategy)
         pytest.param(SamplingStrategy.HYPEREDGE, [0, 1], id="hyperedge_strategy"),
     ],
 )
-def test_getitem_with_multiple_edges_attr(
-    mock_hdata_multiple_edges_attr_hypergraph, strategy, index
-):
-    with patch.object(
-        HIFLoader, "load_by_name", return_value=mock_hdata_multiple_edges_attr_hypergraph
-    ):
+def test_getitem_with_multiple_edges_attr(mock_hdata_multiple_hyperedge_attrs, strategy, index):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_multiple_hyperedge_attrs):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
     data = dataset[index]
@@ -582,11 +561,11 @@ def test_remove_hyperedges_with_fewer_than_k_nodes(hyperedge_index, k, expected_
     assert dataset.hdata.y.shape[0] == expected_num_hyperedges
 
 
-def test_split_with_equal_ratios(mock_hdata_four_node_hypergraph):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+def test_split_with_equal_ratios(mock_hdata_four_nodes):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset()
 
-    splits = dataset.split([0.5, 0.5])
+    splits = dataset.split([0.5, 0.5], node_space_setting="inductive")
 
     assert len(splits) == 2
     assert (
@@ -599,13 +578,32 @@ def test_split_with_equal_ratios(mock_hdata_four_node_hypergraph):
         assert split.hdata.num_hyperedges > 0
 
 
-def test_split_three_way(mock_hdata_multiple_edges_attr_hypergraph):
+def test_split_transductive_with_equal_ratios(mock_hdata_transductive_split):
     with patch.object(
-        HIFLoader, "load_by_name", return_value=mock_hdata_multiple_edges_attr_hypergraph
+        HIFLoader,
+        "load_by_name",
+        return_value=mock_hdata_transductive_split,
     ):
         dataset = AlgebraDataset()
 
-    splits = dataset.split([0.5, 0.25, 0.25])
+    splits = dataset.split([0.5, 0.5], node_space_setting="transductive")
+
+    assert len(splits) == 2
+    assert (
+        splits[0].hdata.num_hyperedges + splits[1].hdata.num_hyperedges
+        == dataset.hdata.num_hyperedges
+    )
+    for split in splits:
+        assert split.hdata.x is not None
+        assert split.hdata.num_nodes > 0
+        assert split.hdata.num_hyperedges > 0
+
+
+def test_split_three_way(mock_hdata_multiple_hyperedge_attrs):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_multiple_hyperedge_attrs):
+        dataset = AlgebraDataset()
+
+    splits = dataset.split([0.5, 0.25, 0.25], node_space_setting="inductive")
     total_edges = sum(split.hdata.num_hyperedges for split in splits)
 
     assert len(splits) == 3
@@ -617,34 +615,122 @@ def test_split_three_way(mock_hdata_multiple_edges_attr_hypergraph):
         assert split.hdata.num_hyperedges > 0
 
 
-def test_split_raises_when_ratios_do_not_sum_to_one(mock_hdata_four_node_hypergraph):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+def test_split_transductive_three_way(
+    mock_hdata_transductive_multiple_hyperedges_attrs,
+):
+    with patch.object(
+        HIFLoader,
+        "load_by_name",
+        return_value=mock_hdata_transductive_multiple_hyperedges_attrs,
+    ):
+        dataset = AlgebraDataset()
+
+    splits = dataset.split([0.5, 0.25, 0.25], node_space_setting="transductive")
+    total_edges = sum(split.hdata.num_hyperedges for split in splits)
+
+    assert len(splits) == 3
+    assert total_edges == dataset.hdata.num_hyperedges
+
+    for split in splits:
+        assert split.hdata.x is not None
+        assert split.hdata.num_nodes > 0
+        assert split.hdata.num_hyperedges > 0
+
+
+def test_split_with_ratios_returns_final_inductive_ratios(
+    mock_hdata_multiple_hyperedge_attrs,
+):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_multiple_hyperedge_attrs):
+        dataset = AlgebraDataset()
+
+    splits, final_ratios = dataset.split_with_ratios(
+        [0.5, 0.25, 0.25],
+        node_space_setting="inductive",
+    )
+
+    assert [split.hdata.num_hyperedges for split in splits] == [1, 1, 1]
+    assert final_ratios == [0.3333, 0.3333, 0.3333]
+
+
+def test_split_raises_when_ratios_do_not_sum_to_one(mock_hdata_four_nodes):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset()
 
     with pytest.raises(ValueError, match=re.escape("Split ratios must sum to 1.0")):
         dataset.split([0.8, 0.1, 0.05])
 
 
-def test_split_with_shuffle_produces_deterministic_results_when_seed_provided(
-    mock_hdata_four_node_hypergraph,
-):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+def test_split_raises_when_a_split_has_zero_hyperedges(mock_hdata_four_nodes):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset()
 
-    splits_a = dataset.split([0.5, 0.5], shuffle=True, seed=42)
-    splits_b = dataset.split([0.5, 0.5], shuffle=True, seed=42)
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Cannot create dataset splits because splits [1] contain no hyperedges. "
+            "Final ratios: [0.5, 0.0, 0.5]."
+        ),
+    ):
+        dataset.split([0.5, 0.25, 0.25], node_space_setting="inductive")
+
+
+def test_split_with_shuffle_produces_deterministic_results_when_seed_provided(
+    mock_hdata_four_nodes,
+):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
+        dataset = AlgebraDataset()
+
+    splits_a = dataset.split(
+        [0.5, 0.5],
+        shuffle=True,
+        seed=42,
+        node_space_setting="inductive",
+    )
+    splits_b = dataset.split(
+        [0.5, 0.5],
+        shuffle=True,
+        seed=42,
+        node_space_setting="inductive",
+    )
+
+    assert torch.equal(splits_a[0].hdata.hyperedge_index, splits_b[0].hdata.hyperedge_index)
+    assert torch.equal(splits_a[1].hdata.hyperedge_index, splits_b[1].hdata.hyperedge_index)
+
+
+def test_split_transductive_with_shuffle_produces_deterministic_results_when_seed_provided(
+    mock_hdata_transductive_split,
+):
+    with patch.object(
+        HIFLoader,
+        "load_by_name",
+        return_value=mock_hdata_transductive_split,
+    ):
+        dataset = AlgebraDataset()
+
+    splits_a = dataset.split(
+        [0.5, 0.5],
+        shuffle=True,
+        seed=42,
+        node_space_setting="transductive",
+    )
+    splits_b = dataset.split(
+        [0.5, 0.5],
+        shuffle=True,
+        seed=42,
+        node_space_setting="transductive",
+    )
 
     assert torch.equal(splits_a[0].hdata.hyperedge_index, splits_b[0].hdata.hyperedge_index)
     assert torch.equal(splits_a[1].hdata.hyperedge_index, splits_b[1].hdata.hyperedge_index)
 
 
 def test_split_with_shuffle_when_no_seed_provided(
-    mock_hdata_four_node_hypergraph,
+    mock_hdata_four_nodes,
 ):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset()
 
-    splits = dataset.split([0.5, 0.5], shuffle=True)
+    splits = dataset.split([0.5, 0.5], shuffle=True, node_space_setting="inductive")
     total_edges = sum(split.hdata.num_hyperedges for split in splits)
 
     assert len(splits) == 2
@@ -656,24 +742,75 @@ def test_split_with_shuffle_when_no_seed_provided(
         assert split.hdata.num_hyperedges > 0
 
 
-def test_split_preserves_edge_attr(mock_hdata_multiple_edges_attr_hypergraph):
+def test_split_transductive_with_shuffle_when_no_seed_provided(
+    mock_hdata_transductive_split,
+):
     with patch.object(
-        HIFLoader, "load_by_name", return_value=mock_hdata_multiple_edges_attr_hypergraph
+        HIFLoader,
+        "load_by_name",
+        return_value=mock_hdata_transductive_split,
     ):
         dataset = AlgebraDataset()
 
-    splits = dataset.split([0.5, 0.5])
+    splits = dataset.split([0.5, 0.5], shuffle=True, node_space_setting="transductive")
+    total_edges = sum(split.hdata.num_hyperedges for split in splits)
+
+    assert len(splits) == 2
+    assert total_edges == dataset.hdata.num_hyperedges
+
+    for split in splits:
+        assert split.hdata.x is not None
+        assert split.hdata.num_nodes > 0
+        assert split.hdata.num_hyperedges > 0
+
+
+def test_split_preserves_edge_attr(mock_hdata_multiple_hyperedge_attrs):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_multiple_hyperedge_attrs):
+        dataset = AlgebraDataset()
+
+    splits = dataset.split([0.5, 0.5], node_space_setting="inductive")
 
     for split in splits:
         assert split.hdata.hyperedge_attr is not None
         assert split.hdata.hyperedge_attr.shape[0] == split.hdata.num_hyperedges
 
 
-def test_split_without_edge_attr(mock_hdata_no_edge_attr_hypergraph):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_no_edge_attr_hypergraph):
+def test_split_transductive_preserves_edge_attr(
+    mock_hdata_transductive_multiple_hyperedges_attrs,
+):
+    with patch.object(
+        HIFLoader,
+        "load_by_name",
+        return_value=mock_hdata_transductive_multiple_hyperedges_attrs,
+    ):
         dataset = AlgebraDataset()
 
-    splits = dataset.split([0.5, 0.5])
+    splits = dataset.split([0.5, 0.5], node_space_setting="transductive")
+
+    for split in splits:
+        assert split.hdata.hyperedge_attr is not None
+        assert split.hdata.hyperedge_attr.shape[0] == split.hdata.num_hyperedges
+
+
+def test_split_without_edge_attr(mock_hdata_four_nodes):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
+        dataset = AlgebraDataset()
+
+    splits = dataset.split([0.5, 0.5], node_space_setting="inductive")
+
+    for split in splits:
+        assert split.hdata.hyperedge_attr is None
+
+
+def test_split_transductive_without_edge_attr(mock_hdata_transductive_split):
+    with patch.object(
+        HIFLoader,
+        "load_by_name",
+        return_value=mock_hdata_transductive_split,
+    ):
+        dataset = AlgebraDataset()
+
+    splits = dataset.split([0.5, 0.5], node_space_setting="transductive")
 
     for split in splits:
         assert split.hdata.hyperedge_attr is None
@@ -690,8 +827,8 @@ def test_to_device(mock_hdata):
     assert dataset.hdata.device == device
 
 
-def test_default_sampling_strategy_is_hyperedge(mock_hdata_four_node_hypergraph):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+def test_default_sampling_strategy_is_hyperedge(mock_hdata_four_nodes):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset()
 
     # Default strategy is HYPEREDGE, so len should be num_hyperedges (2), not num_nodes (4)
@@ -699,8 +836,8 @@ def test_default_sampling_strategy_is_hyperedge(mock_hdata_four_node_hypergraph)
     assert len(dataset) == 2
 
 
-def test_explicit_node_sampling_strategy(mock_hdata_four_node_hypergraph):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+def test_explicit_node_sampling_strategy(mock_hdata_four_nodes):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset(sampling_strategy=SamplingStrategy.NODE)
 
     # NODE strategy, so len should be num_nodes (4), not num_hyperedges (2)
@@ -715,11 +852,35 @@ def test_explicit_node_sampling_strategy(mock_hdata_four_node_hypergraph):
         pytest.param(SamplingStrategy.HYPEREDGE, id="hyperedge_strategy"),
     ],
 )
-def test_split_preserves_sampling_strategy(mock_hdata_four_node_hypergraph, strategy):
-    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_node_hypergraph):
+def test_split_preserves_sampling_strategy(mock_hdata_four_nodes, strategy):
+    with patch.object(HIFLoader, "load_by_name", return_value=mock_hdata_four_nodes):
         dataset = AlgebraDataset(sampling_strategy=strategy)
 
-    splits = dataset.split([0.5, 0.5])
+    splits = dataset.split([0.5, 0.5], node_space_setting="inductive")
+
+    for split in splits:
+        assert split.sampling_strategy == strategy
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        pytest.param(SamplingStrategy.NODE, id="node_strategy"),
+        pytest.param(SamplingStrategy.HYPEREDGE, id="hyperedge_strategy"),
+    ],
+)
+def test_split_transductive_preserves_sampling_strategy(
+    mock_hdata_transductive_split,
+    strategy,
+):
+    with patch.object(
+        HIFLoader,
+        "load_by_name",
+        return_value=mock_hdata_transductive_split,
+    ):
+        dataset = AlgebraDataset(sampling_strategy=strategy)
+
+    splits = dataset.split([0.5, 0.5], node_space_setting="transductive")
 
     for split in splits:
         assert split.sampling_strategy == strategy
@@ -960,11 +1121,12 @@ def test_enrich_node_features_from_dataset_with_fill_value():
     assert torch.equal(target_dataset.hdata.x, torch.tensor([[1.0, 10.0], [7.0, 8.0]]))
 
 
-def test_split_transductive_default_preserves_first_split_node_space():
+def test_split_transductive_rebalances_first_split_to_cover_all_nodes():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
-        hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]]),
+        hyperedge_index=torch.tensor([[0, 1, 2, 3, 0], [0, 1, 2, 3, 4]]),
         global_node_ids=torch.tensor([100, 200, 300, 400]),
+        y=torch.arange(5, dtype=torch.float),
     )
     dataset = Dataset.from_hdata(hdata)
 
@@ -972,54 +1134,98 @@ def test_split_transductive_default_preserves_first_split_node_space():
 
     assert train_dataset.hdata.num_nodes == dataset.hdata.num_nodes
     assert torch.equal(train_dataset.hdata.x, dataset.hdata.x)
-    assert test_dataset.hdata.num_nodes == 1
+    assert torch.equal(
+        train_dataset.hdata.hyperedge_index[0].unique(sorted=True),
+        torch.arange(hdata.num_nodes),
+    )
+    # The only way to cover all 4 nodes with 75% of the hyperedges is to:
+    # - Put 3 hyperedges in the train split.
+    # - Put 1 hyperedge in the test split.
+    assert train_dataset.hdata.num_hyperedges == dataset.hdata.num_hyperedges - 1
+    assert test_dataset.hdata.num_hyperedges == 1
+
+    split_labels = torch.cat([train_dataset.hdata.y, test_dataset.hdata.y])
+    assert split_labels.unique().numel() == dataset.hdata.num_hyperedges
+    assert torch.equal(split_labels.sort().values, hdata.y)
 
 
-def test_split_transductive_all_preserves_all_split_node_spaces():
+def test_split_with_ratios_returns_final_transductive_ratios():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
-        hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]]),
-        global_node_ids=torch.tensor([100, 200, 300, 400]),
+        hyperedge_index=torch.tensor([[0, 1, 2, 3, 0], [0, 1, 2, 3, 4]]),
     )
     dataset = Dataset.from_hdata(hdata)
 
-    train_dataset, test_dataset = dataset.split(
-        [0.75, 0.25],
-        node_space_setting="transductive",
-        assign_node_space_to="all",
+    splits, final_ratios = dataset.split_with_ratios([0.75, 0.25])
+
+    assert [split.hdata.num_hyperedges for split in splits] == [4, 1]
+    assert final_ratios == pytest.approx([0.8, 0.2])
+
+
+def test_split_with_ratios_transductive_keeps_ratios_when_train_covers_all_nodes():
+    hdata = HData(
+        x=torch.arange(4, dtype=torch.float).unsqueeze(1),
+        hyperedge_index=torch.tensor(
+            [
+                [0, 1, 2, 3, 0, 2, 1, 3],
+                [0, 0, 1, 1, 2, 2, 3, 3],
+            ]
+        ),
+    )
+    dataset = Dataset.from_hdata(hdata)
+
+    splits, final_ratios = dataset.split_with_ratios([0.5, 0.5])
+
+    assert [split.hdata.num_hyperedges for split in splits] == [2, 2]
+    assert final_ratios == pytest.approx([0.5, 0.5])
+    assert torch.equal(
+        splits[0].hdata.hyperedge_index[0].unique(sorted=True),
+        torch.arange(hdata.num_nodes),
     )
 
-    assert train_dataset.hdata.num_nodes == dataset.hdata.num_nodes
-    assert test_dataset.hdata.num_nodes == dataset.hdata.num_nodes
-    assert torch.equal(train_dataset.hdata.x, dataset.hdata.x)
-    assert torch.equal(test_dataset.hdata.x, dataset.hdata.x)
 
-
-def test_split_raises_when_node_space_provided_with_transductive_disabled():
+def test_split_transductive_raises_when_rebalancing_empties_a_split():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]]),
-        global_node_ids=torch.tensor([100, 200, 300, 400]),
     )
     dataset = Dataset.from_hdata(hdata)
 
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "assign_node_space_to can only be provided when node_space_setting='transductive'."
+            "Cannot create dataset splits because splits [1] contain no hyperedges. "
+            "Final ratios: [1.0, 0.0]."
         ),
     ):
-        dataset.split(
-            [0.75, 0.25],
-            node_space_setting="inductive",
-            assign_node_space_to="first",
-        )
+        dataset.split([0.75, 0.25])
+
+
+def test_split_transductive_raises_when_a_node_is_missing_from_all_hyperedges():
+    hdata = HData(
+        x=torch.arange(4, dtype=torch.float).unsqueeze(1),
+        hyperedge_index=torch.tensor([[0, 1, 2], [0, 0, 1]]),
+    )
+    dataset = Dataset.from_hdata(hdata)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Cannot create a transductive first split covering all nodes because these node ids do not appear in any hyperedge: [3]."
+        ),
+    ):
+        dataset.split([0.5, 0.5], node_space_setting="transductive")
 
 
 def test_nested_transductive_split_supports_train_feature_reuse():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
-        hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]]),
+        hyperedge_index=torch.tensor(
+            [
+                [0, 1, 2, 3, 0, 1, 2, 3],
+                [0, 0, 0, 0, 1, 1, 2, 3],
+            ]
+        ),
         global_node_ids=torch.tensor([100, 200, 300, 400]),
     )
     dataset = Dataset.from_hdata(hdata)

--- a/hyperbench/tests/data/splitter_test.py
+++ b/hyperbench/tests/data/splitter_test.py
@@ -1,0 +1,128 @@
+import torch
+import pytest
+import re
+
+from hyperbench.data import HyperedgeIDSplitter
+from hyperbench.types import HData
+
+
+@pytest.fixture
+def mock_hdata_five_hyperedges():
+    x = torch.ones((4, 1), dtype=torch.float)
+    hyperedge_index = torch.tensor(
+        [
+            [0, 1, 2, 3, 0],
+            [0, 1, 2, 3, 4],
+        ],
+        dtype=torch.long,
+    )
+    return HData(x=x, hyperedge_index=hyperedge_index)
+
+
+def test_get_split_ratios_returns_zero_ratios_when_all_splits_are_empty():
+    splitter = HyperedgeIDSplitter(HData.empty())
+    empty_split = torch.empty(0, dtype=torch.long)
+
+    split_ratios = splitter.get_split_ratios([empty_split, empty_split])
+
+    assert split_ratios == [0.0, 0.0]
+
+
+def test_get_hyperedge_ids_permutation_returns_original_order_without_shuffle(
+    mock_hdata_five_hyperedges,
+):
+    splitter = HyperedgeIDSplitter(mock_hdata_five_hyperedges)
+    permutation = splitter.get_hyperedge_ids_permutation(shuffle=False, seed=123)
+
+    assert torch.equal(permutation, torch.arange(5))
+
+
+def test_get_hyperedge_ids_permutation_is_deterministic_with_seed(
+    mock_hdata_five_hyperedges,
+):
+    shuffle = True
+    seed = 123
+
+    splitter = HyperedgeIDSplitter(mock_hdata_five_hyperedges)
+    permutation_a = splitter.get_hyperedge_ids_permutation(shuffle, seed)
+    permutation_b = splitter.get_hyperedge_ids_permutation(shuffle, seed)
+
+    assert torch.equal(permutation_a, permutation_b)
+    assert torch.equal(permutation_a.sort().values, torch.arange(5))
+
+
+def test_split_uses_cumulative_floor_boundaries_and_last_split_absorbs_remainder(
+    mock_hdata_five_hyperedges,
+):
+    hyperedge_ids = torch.arange(5)
+
+    splitter = HyperedgeIDSplitter(mock_hdata_five_hyperedges)
+    split_hyperedge_ids, final_ratios = splitter.split(hyperedge_ids, [0.5, 0.25, 0.25])
+
+    assert [split.tolist() for split in split_hyperedge_ids] == [[0, 1], [2], [3, 4]]
+    assert final_ratios == [0.4, 0.2, 0.4]
+
+
+def test_ensure_split_covers_all_nodes_moves_best_covering_hyperedge_into_first_split():
+    x = torch.ones((4, 1), dtype=torch.float)
+    hyperedge_index = torch.tensor(
+        [
+            [0, 1, 2, 3, 0, 1, 2, 3],
+            [0, 1, 2, 3, 4, 4, 4, 4],
+        ],
+        dtype=torch.long,
+    )
+    hdata = HData(x=x, hyperedge_index=hyperedge_index)
+    splitter = HyperedgeIDSplitter(hdata)
+
+    hyperedge_ids_by_split = [
+        torch.tensor([0, 1], dtype=torch.long),
+        torch.tensor([2, 3, 4], dtype=torch.long),
+    ]
+
+    updated_split_hyperedge_ids, final_ratios = splitter.ensure_split_covers_all_nodes(
+        hyperedge_ids_by_split
+    )
+
+    assert set(updated_split_hyperedge_ids[0].tolist()) == {0, 1, 4}
+    assert set(updated_split_hyperedge_ids[1].tolist()) == {2, 3}
+    assert final_ratios == [0.6, 0.4]
+
+
+def test_ensure_split_covers_all_nodes_raises_when_a_node_is_missing_from_hypergraph():
+    x = torch.ones((4, 1), dtype=torch.float)
+    hyperedge_index = torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long)
+    hdata = HData(x=x, hyperedge_index=hyperedge_index)
+    splitter = HyperedgeIDSplitter(hdata)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Cannot create a transductive first split covering all nodes because these node ids do not appear in any hyperedge: [3]."
+        ),
+    ):
+        splitter.ensure_split_covers_all_nodes(
+            [
+                torch.tensor([0], dtype=torch.long),
+                torch.tensor([1], dtype=torch.long),
+            ]
+        )
+
+
+def test_validate_splits_have_hyperedges_raises_when_a_split_is_empty(
+    mock_hdata_five_hyperedges,
+):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Cannot create dataset splits because splits [1] contain no hyperedges. Final ratios: [0.6, 0.0, 0.4]."
+        ),
+    ):
+        splitter = HyperedgeIDSplitter(mock_hdata_five_hyperedges)
+        splitter.validate_splits_have_hyperedges(
+            [
+                torch.tensor([0, 1, 2], dtype=torch.long),
+                torch.empty(0, dtype=torch.long),
+                torch.tensor([3, 4], dtype=torch.long),
+            ]
+        )

--- a/hyperbench/tests/mock/__init__.py
+++ b/hyperbench/tests/mock/__init__.py
@@ -1,3 +1,13 @@
-from .mock import MOCK_BASE_PATH, new_mock_named_temporary_file, new_mock_trainer
+from .mock import (
+    MOCK_BASE_PATH,
+    new_mock_named_temporary_file,
+    new_mock_trainer,
+    new_mock_negative_sampler,
+)
 
-__all__ = ["MOCK_BASE_PATH", "new_mock_named_temporary_file", "new_mock_trainer"]
+__all__ = [
+    "MOCK_BASE_PATH",
+    "new_mock_named_temporary_file",
+    "new_mock_negative_sampler",
+    "new_mock_trainer",
+]

--- a/hyperbench/tests/mock/mock.py
+++ b/hyperbench/tests/mock/mock.py
@@ -1,8 +1,12 @@
+import torch
+
 from os import PathLike
 from typing import IO, Any
 from collections.abc import Iterator
 from unittest.mock import MagicMock
 from contextlib import contextmanager
+from hyperbench.train import NegativeSampler
+from hyperbench.types import HData
 
 
 MOCK_BASE_PATH = "hyperbench/tests/mock"
@@ -24,3 +28,26 @@ def new_mock_named_temporary_file(
 ) -> Iterator[IO[Any]]:
     with open(path, mode) as file_handle:
         yield file_handle
+
+
+def new_mock_negative_sampler():
+    def sample(data: HData, seed: int | None = None) -> HData:
+        negative_nodes = torch.tensor([0, 2], dtype=torch.long, device=data.device)
+        negative_hyperedge_id = torch.full(
+            negative_nodes.shape,
+            data.num_hyperedges,
+            dtype=torch.long,
+            device=data.device,
+        )
+        return HData(
+            x=data.x,
+            hyperedge_index=torch.stack([negative_nodes, negative_hyperedge_id]),
+            num_nodes=data.num_nodes,
+            num_hyperedges=1,
+            global_node_ids=data.global_node_ids,
+            y=torch.zeros(1, dtype=torch.float, device=data.device),
+        )
+
+    sampler = MagicMock(spec=NegativeSampler)
+    sampler.sample.side_effect = sample
+    return sampler

--- a/hyperbench/tests/types/hypergraph_test.py
+++ b/hyperbench/tests/types/hypergraph_test.py
@@ -612,6 +612,15 @@ def test_clique_expansion_overlapping_hyperedges():
     assert (2, 1) in edges
 
 
+def test_clique_expansion_uses_explicit_transductive_num_nodes():
+    hyperedge_index = torch.tensor([[0, 3], [0, 0]], dtype=torch.long)
+
+    result = HyperedgeIndex(hyperedge_index).reduce_to_edge_index_on_clique_expansion(num_nodes=5)
+    edges = set(zip(result[0].tolist(), result[1].tolist(), strict=True))
+
+    assert edges == {(0, 0), (0, 3), (3, 0), (3, 3)}
+
+
 @pytest.mark.parametrize(
     "hyperedge_index_tensor, num_nodes, expected_adjacency",
     [
@@ -1272,6 +1281,20 @@ def test_get_sparse_incidence_matrix_sums_duplicate_incidences_when_coalesced():
     assert incidence_matrix.is_sparse
     assert incidence_matrix.shape == (2, 2)
     assert torch.allclose(incidence_matrix.to_dense(), expected_incidence_matrix, atol=1e-6)
+
+
+def test_get_sparse_incidence_matrix_rejects_explicit_num_nodes_too_small():
+    hyperedge_index = HyperedgeIndex(torch.tensor([[0, 1, 2], [0, 0, 0]], dtype=torch.long))
+
+    with pytest.raises(ValueError, match="num_nodes is too small"):
+        hyperedge_index.get_sparse_incidence_matrix(num_nodes=2)
+
+
+def test_get_sparse_incidence_matrix_rejects_explicit_num_hyperedges_too_small():
+    hyperedge_index = HyperedgeIndex(torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long))
+
+    with pytest.raises(ValueError, match="num_hyperedges is too small"):
+        hyperedge_index.get_sparse_incidence_matrix(num_hyperedges=1)
 
 
 def test_get_sparse_symnormalized_node_degree_matrix_is_expected_diagonal():

--- a/hyperbench/tests/utils/node_utils_test.py
+++ b/hyperbench/tests/utils/node_utils_test.py
@@ -3,11 +3,8 @@ import torch
 
 from hyperbench.utils import (
     assign_hyperedge_label_to_nodes,
-    is_assigned_to_all,
-    is_assigned_to_first,
     is_inductive_setting,
     is_transductive_setting,
-    is_transductive_split,
 )
 
 
@@ -71,30 +68,6 @@ def test_assign_hyperedge_label_to_nodes_returns_empty_mapping_without_hyperedge
 
 
 @pytest.mark.parametrize(
-    "node_space_assignment, expected",
-    [
-        pytest.param("all", True, id="all"),
-        pytest.param("first", False, id="first"),
-        pytest.param(None, False, id="none"),
-    ],
-)
-def test_is_assigned_to_all(node_space_assignment, expected):
-    assert is_assigned_to_all(node_space_assignment) == expected
-
-
-@pytest.mark.parametrize(
-    "node_space_assignment, expected",
-    [
-        pytest.param("first", True, id="first"),
-        pytest.param("all", False, id="all"),
-        pytest.param(None, False, id="none"),
-    ],
-)
-def test_is_assigned_to_first(node_space_assignment, expected):
-    assert is_assigned_to_first(node_space_assignment) == expected
-
-
-@pytest.mark.parametrize(
     "node_space_setting, expected",
     [
         pytest.param("inductive", True, id="inductive"),
@@ -116,20 +89,3 @@ def test_is_inductive_setting(node_space_setting, expected):
 )
 def test_is_transductive_setting(node_space_setting, expected):
     assert is_transductive_setting(node_space_setting) == expected
-
-
-@pytest.mark.parametrize(
-    "node_space_setting, assign_node_space_to, split_num, expected",
-    [
-        pytest.param("inductive", "all", 0, False, id="inductive_all_first_split"),
-        pytest.param("inductive", "first", 0, False, id="inductive_first_first_split"),
-        pytest.param(None, "all", 0, False, id="none_setting"),
-        pytest.param("transductive", "all", 0, True, id="transductive_all_first_split"),
-        pytest.param("transductive", "all", 2, True, id="transductive_all_later_split"),
-        pytest.param("transductive", "first", 0, True, id="transductive_first_first_split"),
-        pytest.param("transductive", "first", 1, False, id="transductive_first_later_split"),
-        pytest.param("transductive", None, 0, False, id="transductive_none_assignment"),
-    ],
-)
-def test_is_transductive_split(node_space_setting, assign_node_space_to, split_num, expected):
-    assert is_transductive_split(node_space_setting, assign_node_space_to, split_num) == expected

--- a/hyperbench/types/hdata.py
+++ b/hyperbench/types/hdata.py
@@ -273,7 +273,7 @@ class HData:
             hdata: The original `HData` containing the full hypergraph.
             split_hyperedge_ids: Tensor of hyperedge IDs to include in this split.
             node_space_setting: Whether to preserve the full node space in the splits.
-                ``transductive`` (default) ensures all nodes are present in every split,
+                ``transductive`` (default) ensures all node features are present in the split,
                 while ``inductive`` allows splits to have disjoint node spaces.
 
         Returns:
@@ -306,7 +306,7 @@ class HData:
         if hdata.hyperedge_weights is not None:
             split_hyperedge_weights = hdata.hyperedge_weights[split_unique_hyperedge_ids]
 
-        # We don't need to split nodes, so we split only hyperedges and rebase their IDs to 0-based
+        # We don't rebase nodes as they are all present in a transductive setting
         if is_transductive_setting(node_space_setting):
             # Example: split_unique_hyperedge_ids = [2, 5]
             #          -> hyperedge 2 -> 0, hyperedge 5 -> 1

--- a/hyperbench/types/hypergraph.py
+++ b/hyperbench/types/hypergraph.py
@@ -507,10 +507,27 @@ class HyperedgeIndex:
 
         Returns:
             incidence_matrix: The sparse incidence matrix H of shape ``(num_nodes, num_hyperedges)``.
+
+        Raises:
+            ValueError: If the provided dimensions cannot contain the raw node or hyperedge IDs.
         """
         device = self.__hyperedge_index.device
         num_nodes = num_nodes if num_nodes is not None else self.num_nodes
         num_hyperedges = num_hyperedges if num_hyperedges is not None else self.num_hyperedges
+        if self.num_incidences > 0:
+            max_node_id = int(self.all_node_ids.max().item())
+            if max_node_id >= num_nodes:
+                raise ValueError(
+                    "num_nodes is too small for the hyperedge index. "
+                    f"Got num_nodes={num_nodes}, but max node id is {max_node_id}."
+                )
+            max_hyperedge_id = int(self.all_hyperedge_ids.max().item())
+            if max_hyperedge_id >= num_hyperedges:
+                raise ValueError(
+                    "num_hyperedges is too small for the hyperedge index. "
+                    f"Got num_hyperedges={num_hyperedges}, "
+                    f"but max hyperedge id is {max_hyperedge_id}."
+                )
 
         incidence_values = torch.ones(self.num_incidences, dtype=torch.float, device=device)
         incidence_indices = torch.stack([self.all_node_ids, self.all_hyperedge_ids], dim=0)
@@ -770,9 +787,13 @@ class HyperedgeIndex:
         """
         match strategy:
             case _:
-                return self.reduce_to_edge_index_on_clique_expansion()
+                return self.reduce_to_edge_index_on_clique_expansion(**kwargs)
 
-    def reduce_to_edge_index_on_clique_expansion(self) -> Tensor:
+    def reduce_to_edge_index_on_clique_expansion(
+        self,
+        num_nodes: int | None = None,
+        num_hyperedges: int | None = None,
+    ) -> Tensor:
         """
         Construct a graph from a hypergraph via clique expansion using ``H @ H^T``, where ``H`` is the incidence matrix of the hypergraph.
         In clique expansion, each hyperedge is replaced by a clique connecting all its member nodes.
@@ -781,10 +802,17 @@ class HyperedgeIndex:
         This is computed efficiently using the incidence matrix: ``A = H @ H^T``, where ``H`` is
         the sparse incidence matrix of shape ``[num_nodes, num_hyperedges]`` and ``A`` is the adjacency matrix of the clique-expanded graph.
 
+        Args:
+            num_nodes: Total number of nodes. If ``None``, inferred from hyperedge index.
+            num_hyperedges: Total number of hyperedges. If ``None``, inferred from hyperedge index.
+
         Returns:
             edge_index: The edge index of the clique-expanded graph. Size ``(2, |E'|)``.
         """
-        incidence_matrix = self.get_sparse_incidence_matrix()
+        incidence_matrix = self.get_sparse_incidence_matrix(
+            num_nodes=num_nodes,
+            num_hyperedges=num_hyperedges,
+        )
 
         # A = H @ H^T gives adjacency with self-loops on diagonal
         # Example: For hyperedge_index = [[0, 1, 2, 0],
@@ -807,7 +835,7 @@ class HyperedgeIndex:
         adj_matrix = torch.sparse.mm(incidence_matrix, incidence_matrix.t()).coalesce()
 
         # Extract edge_index, make undirected, and deduplicate
-        return EdgeIndex(adj_matrix.indices()).to_undirected().item
+        return EdgeIndex(adj_matrix.indices()).to_undirected(num_nodes=num_nodes).item
 
     def reduce_to_edge_index_on_random_direction(
         self,

--- a/hyperbench/utils/__init__.py
+++ b/hyperbench/utils/__init__.py
@@ -22,15 +22,11 @@ from .nn_utils import (
     maxmin_scatter,
 )
 from .node_utils import (
-    NodeSpaceAssignment,
     NodeSpaceFiller,
     NodeSpaceSetting,
     assign_hyperedge_label_to_nodes,
-    is_assigned_to_all,
-    is_assigned_to_first,
     is_inductive_setting,
     is_transductive_setting,
-    is_transductive_split,
 )
 from .random_utils import create_seeded_torch_generator
 from .sparse_utils import sparse_dropout
@@ -40,7 +36,6 @@ from .file_utils import decompress_zst, compress_to_zst, write_to_disk, named_te
 __all__ = [
     "INPUT_LAYER",
     "ActivationFn",
-    "NodeSpaceAssignment",
     "NodeSpaceFiller",
     "NodeSpaceSetting",
     "NormalizationFn",
@@ -56,13 +51,10 @@ __all__ = [
     "get_gh_datasets_shas",
     "get_hf_dataset_sha",
     "get_hf_datasets_shas",
-    "is_assigned_to_all",
-    "is_assigned_to_first",
     "is_inductive_setting",
     "is_input_layer",
     "is_layer",
     "is_transductive_setting",
-    "is_transductive_split",
     "maxmin_scatter",
     "named_temporary_file",
     "sparse_dropout",

--- a/hyperbench/utils/node_utils.py
+++ b/hyperbench/utils/node_utils.py
@@ -3,7 +3,6 @@ from typing import Literal, TypeAlias
 from collections.abc import Sequence
 
 
-NodeSpaceAssignment: TypeAlias = Literal["first", "all"]
 NodeSpaceFiller: TypeAlias = float | int | Sequence[float] | Tensor
 NodeSpaceSetting: TypeAlias = Literal["inductive", "transductive"]
 
@@ -21,29 +20,9 @@ def assign_hyperedge_label_to_nodes(
     return labels_by_nodes
 
 
-def is_assigned_to_all(node_space_assignment: NodeSpaceAssignment | None) -> bool:
-    return node_space_assignment == "all"
-
-
-def is_assigned_to_first(node_space_assignment: NodeSpaceAssignment | None) -> bool:
-    return node_space_assignment == "first"
-
-
 def is_inductive_setting(node_space_setting: NodeSpaceSetting | None) -> bool:
     return node_space_setting == "inductive"
 
 
 def is_transductive_setting(node_space_setting: NodeSpaceSetting | None) -> bool:
     return node_space_setting == "transductive"
-
-
-def is_transductive_split(
-    node_space_setting: NodeSpaceSetting | None,
-    assign_node_space_to: NodeSpaceAssignment | None,
-    split_num: int,
-) -> bool:
-    if not is_transductive_setting(node_space_setting):
-        return False
-    if is_assigned_to_all(assign_node_space_to):
-        return True
-    return is_assigned_to_first(assign_node_space_to) and split_num == 0


### PR DESCRIPTION
### All Submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Fix transductive `split` to include all nodes in the train split.
- Fix `reduce_to_edge_index_on_clique_expansion` to support `num_nodes` and `num_hyperedges` as parameters.
- Update documentation and docstrings.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make format`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
