### PR TITLE
feat: add logger configs to MultiModelTrainer

### DIFF
--- a/hyperbench/tests/train/trainer_test.py
+++ b/hyperbench/tests/train/trainer_test.py
@@ -1412,3 +1412,153 @@ def test_init_always_create_default_markdown_logger_per_model(
     for call in mock_markdown_logger_cls.call_args_list:
         assert call.kwargs["model_name"] in full_model_names
         assert call.kwargs["experiment_name"] == "experiment_0"
+
+
+@patch("hyperbench.train.trainer.L.Trainer")
+@patch("hyperbench.train.trainer.CSVLogger")
+@patch("hyperbench.train.trainer.MarkdownTableLogger")
+@patch("hyperbench.train.trainer.LaTexTableLogger")
+def test_init_passes_default_precision_to_markdown_logger(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+):
+    MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=str(tmp_path),
+        experiment_name="experiment_0",
+    )
+
+    for call in mock_md_logger_cls.call_args_list:
+        assert call.kwargs["precision"] == 4
+
+
+@patch("hyperbench.train.trainer.L.Trainer")
+@patch("hyperbench.train.trainer.CSVLogger")
+@patch("hyperbench.train.trainer.MarkdownTableLogger")
+@patch("hyperbench.train.trainer.LaTexTableLogger")
+def test_init_passes_custom_precision_to_markdown_logger(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+):
+    MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=str(tmp_path),
+        experiment_name="experiment_0",
+        markdown_logger_config={"precision": 6},
+    )
+
+    for call in mock_md_logger_cls.call_args_list:
+        assert call.kwargs["precision"] == 6
+
+
+@patch("hyperbench.train.trainer.L.Trainer")
+@patch("hyperbench.train.trainer.CSVLogger")
+@patch("hyperbench.train.trainer.MarkdownTableLogger")
+@patch("hyperbench.train.trainer.LaTexTableLogger")
+def test_init_passes_default_options_to_latex_logger(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+):
+    MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=str(tmp_path),
+        experiment_name="experiment_0",
+    )
+
+    for call in mock_latex_logger_cls.call_args_list:
+        assert call.kwargs["precision"] == 4
+        assert call.kwargs["options"] == {
+            "table_caption": "Results for Experiments",
+            "sort_by": ["des", "asc"],
+            "border": False,
+        }
+
+
+@patch("hyperbench.train.trainer.L.Trainer")
+@patch("hyperbench.train.trainer.CSVLogger")
+@patch("hyperbench.train.trainer.MarkdownTableLogger")
+@patch("hyperbench.train.trainer.LaTexTableLogger")
+def test_init_passes_custom_config_to_latex_logger(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+):
+    MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=str(tmp_path),
+        experiment_name="experiment_0",
+        latex_logger_config={
+            "precision": 2,
+            "table_caption": "Custom Caption",
+            "sort_by": ["asc", "asc"],
+            "border": True,
+        },
+    )
+
+    for call in mock_latex_logger_cls.call_args_list:
+        assert call.kwargs["precision"] == 2
+        assert call.kwargs["options"] == {
+            "table_caption": "Custom Caption",
+            "sort_by": ["asc", "asc"],
+            "border": True,
+        }
+
+
+@patch("hyperbench.train.trainer.L.Trainer")
+@patch("hyperbench.train.trainer.CSVLogger")
+@patch("hyperbench.train.trainer.MarkdownTableLogger")
+@patch("hyperbench.train.trainer.LaTexTableLogger")
+def test_init_latex_logger_config_partial_override_keeps_defaults(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+):
+    MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=str(tmp_path),
+        experiment_name="experiment_0",
+        latex_logger_config={"border": True},
+    )
+
+    for call in mock_latex_logger_cls.call_args_list:
+        assert call.kwargs["precision"] == 4
+        assert call.kwargs["options"] == {
+            "table_caption": "Results for Experiments",
+            "sort_by": ["des", "asc"],
+            "border": True,
+        }
+
+
+@patch("hyperbench.train.trainer.L.Trainer")
+def test_init_logger_configs_ignored_when_custom_logger_provided(
+    mock_trainer_cls,
+    mock_model_configs,
+):
+    custom_logger = MagicMock()
+    MultiModelTrainer(
+        mock_model_configs,
+        logger=custom_logger,
+        markdown_logger_config={"precision": 10},
+        latex_logger_config={"precision": 10, "border": True},
+    )
+
+    for call_args in mock_trainer_cls.call_args_list:
+        assert call_args.kwargs["logger"] is custom_logger

--- a/hyperbench/train/__init__.py
+++ b/hyperbench/train/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from .latex_logger import LaTexTableConfig, LaTexTableLogger, colorize_metric_value
 
-from .markdown_logger import MarkdownTableLogger
+from .markdown_logger import MarkdownTableConfig, MarkdownTableLogger
 
 from .trainer import MultiModelTrainer
 
@@ -11,6 +11,7 @@ logging.getLogger("lightning.pytorch").setLevel(logging.ERROR)
 __all__ = [
     "LaTexTableConfig",
     "LaTexTableLogger",
+    "MarkdownTableConfig",
     "MarkdownTableLogger",
     "MultiModelTrainer",
     "colorize_metric_value",

--- a/hyperbench/train/latex_logger.py
+++ b/hyperbench/train/latex_logger.py
@@ -66,15 +66,16 @@ def colorize_metric_value(
 
 
 class LaTexTableConfig(TypedDict):
-    """
-    Configuration for the LaTex table logger.
+    """Configuration for the LaTex table logger.
 
     Attributes:
+        precision: Decimal places for metric values in the table.
         table_caption: Caption for the LaTex table.
         sort_by: Per-column sorting criteria ("asc" or "des").
         border: Whether to include borders in the LaTex table.
     """
 
+    precision: NotRequired[int]
     table_caption: NotRequired[str]
     sort_by: NotRequired[list[str]]
     border: NotRequired[bool]

--- a/hyperbench/train/markdown_logger.py
+++ b/hyperbench/train/markdown_logger.py
@@ -1,10 +1,21 @@
 import copy
 
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypedDict
 from lightning.pytorch.loggers import Logger
 from collections.abc import Mapping
+from typing_extensions import NotRequired
 from hyperbench.utils import validate_is_non_negative
+
+
+class MarkdownTableConfig(TypedDict):
+    """Configuration for the Markdown table logger.
+
+    Attributes:
+        precision: Decimal places for metric values in the table.
+    """
+
+    precision: NotRequired[int]
 
 
 class MarkdownTableLogger(Logger):

--- a/hyperbench/train/trainer.py
+++ b/hyperbench/train/trainer.py
@@ -19,8 +19,8 @@ from hyperbench.data import DataLoader
 from hyperbench.types import CkptStrategy, ModelConfig, TestResult
 from hyperbench.utils import validate_is_non_empty, validate_is_non_negative
 
-from hyperbench.train.markdown_logger import MarkdownTableLogger
-from hyperbench.train.latex_logger import LaTexTableLogger
+from hyperbench.train.markdown_logger import MarkdownTableConfig, MarkdownTableLogger
+from hyperbench.train.latex_logger import LaTexTableConfig, LaTexTableLogger
 
 
 class MultiModelTrainer:
@@ -138,6 +138,17 @@ class MultiModelTrainer:
             :meth:`wait` inside `finalize` before terminating the server, so the user
             can inspect results before the process is stopped.
             Defaults to ``False``.
+
+        markdown_logger_config: Configuration for the default ``MarkdownTableLogger``.
+            Accepts a ``MarkdownTableConfig`` dict with optional keys such as ``precision``.
+            Only used when ``logger`` is not provided.
+            Defaults to ``None``.
+
+        latex_logger_config: Configuration for the default ``LaTexTableLogger``.
+            Accepts a ``LaTexTableConfig`` dict with optional keys such as ``precision``,
+            ``table_caption``, ``sort_by``, and ``border``.
+            Only used when ``logger`` is not provided.
+            Defaults to ``None``.
     """
 
     DEFAULT_BASE_LOG_DIR = "hyperbench_logs"
@@ -180,6 +191,8 @@ class MultiModelTrainer:
         auto_start_tensorboard: bool = False,
         tensorboard_port: int = 6006,
         auto_wait: bool = False,
+        markdown_logger_config: MarkdownTableConfig | None = None,
+        latex_logger_config: LaTexTableConfig | None = None,
         **kwargs,
     ) -> None:
         self.auto_wait = auto_wait
@@ -195,6 +208,12 @@ class MultiModelTrainer:
         self.tensorboard_port = tensorboard_port
         self.__checkpoint_callback_kwargs = (
             checkpoint_callback_kwargs if checkpoint_callback_kwargs is not None else {}
+        )
+        self.__markdown_logger_config: MarkdownTableConfig = (
+            markdown_logger_config if markdown_logger_config is not None else {}
+        )
+        self.__latex_logger_config: LaTexTableConfig = (
+            latex_logger_config if latex_logger_config is not None else {}
         )
 
         full_model_name_counts = self.__full_model_name_counts(model_configs)
@@ -515,15 +534,19 @@ class MultiModelTrainer:
                 save_dir=self.log_dir,
                 model_name=model_config.full_model_name(),
                 experiment_name=experiment_name,
+                precision=self.__markdown_logger_config.get("precision", 4),
             ),
             LaTexTableLogger(
                 save_dir=self.log_dir,
                 model_name=model_config.full_model_name(),
                 experiment_name=experiment_name,
+                precision=self.__latex_logger_config.get("precision", 4),
                 options={
-                    "table_caption": "Results for Experiments",
-                    "sort_by": ["des", "asc"],
-                    "border": False,
+                    "table_caption": self.__latex_logger_config.get(
+                        "table_caption", "Results for Experiments"
+                    ),
+                    "sort_by": self.__latex_logger_config.get("sort_by", ["des", "asc"]),
+                    "border": self.__latex_logger_config.get("border", False),
                 },
             ),
         ]


### PR DESCRIPTION
### All submissions

- [ ] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [ ] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Add `markdown_logger_config` and `latex_logger_config` parameters to
`MultiModelTrainer` so external users can customize the default
MarkdownTableLogger and LaTexTableLogger (e.g. precision, table caption,
sort order, borders) without providing a fully custom logger.

- Add `MarkdownTableConfig` TypedDict with optional `precision` key
- Add `precision` key to existing `LaTexTableConfig` TypedDict
- Wire both configs through `__setup_logger` with backward-compatible defaults
- Export `MarkdownTableConfig` from `hyperbench.train`
- Add 7 unit tests covering defaults, custom values, partial overrides,
  and custom-logger bypass

### Checklist

- [ ] Does your submission pass all tests? (use `make test`)
- [ ] Have you written tests to cover all your changes? If not, provide a reason.
- [ ] Have you lint your code locally before submission? (use `make format`)
- [ ] Have you type checked your code locally before submission? (use `make typecheck`)
