### PR TITLE
docs: add docstrings for MultiModelTrainer and DataLoader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ format:
 
 typecheck:
 	@echo '=== Type checking ==='
-	$(UV) run $(TYPECHECKER) check
+	$(UV) run $(TYPECHECKER) check --error-on-warning
 
 docstring-check:
 	@echo '=== Docstring checking ==='

--- a/hyperbench/data/enricher.py
+++ b/hyperbench/data/enricher.py
@@ -27,7 +27,7 @@ class _VilLainTrainer:
     The helper owns the common configuration, node and hyperedge count resolution,
     model construction, and training loop used by node feature and hyperedge attribute enrichers.
 
-    Args:
+    Attributes:
         num_features: Dimensionality of the embeddings to generate.
         num_nodes: Total number of nodes, including isolated nodes missing from ``hyperedge_index``.
         num_hyperedges: Total number of hyperedges, including empty hyperedges missing

--- a/hyperbench/data/loader.py
+++ b/hyperbench/data/loader.py
@@ -8,12 +8,68 @@ from hyperbench.types import HData, HyperedgeIndex
 
 
 class DataLoader(TorchDataLoader):
+    """
+    DataLoader combines a dataset and a sampler, and provides an iterable
+    over the given dataset. It extends ``torch.utils.data.DataLoader``.
+
+    Attributes:
+        dataset: Dataset that provides sampled `HData` objects.
+        batch_size: Number of samples per batch. Ignored when
+            ``sample_full_hypergraph`` is ``True`` because the full dataset
+            is loaded as one batch.
+        shuffle: Whether to reshuffle sample indices at every epoch.
+        sample_full_hypergraph: Whether each batch should contain the dataset's full
+            hypergraph instead of the sampled items.
+        drop_last: Whether to drop the final incomplete batch when the dataset size
+            is not divisible by the batch size. If ``True``, drop the last incomplete batch.
+            If ``False``, the last batch will be kept and will be smaller.
+            Defaults to ``False``.
+        num_workers: Optional number of subprocesses to use for data loading.
+            For instance, ``0`` means loading happens in the main process. Defaults to ``0``.
+        persistent_workers: Whether worker processes should stay alive after a dataset has
+            been consumed once. If ``True``, the data loader will not shut down
+            the worker processes after a dataset has been consumed once. This allows to
+            maintain the workers `Dataset` instances alive. Defaults to ``False``.
+        collate_fn: Optional custom collate function. When ``None``, uses
+            the default `collate` method.
+        generator: Optional random generator used by the underlying Torch data loader.
+        kwargs:
+            sampler: Defines the strategy to draw samples from the dataset.
+                Can be any ``Iterable`` with ``__len__`` implemented.
+                Mutually exclusive with ``shuffle``. Defaults to ``None``.
+            batch_sampler: Defines the strategy to draw batches of indices. Mutually exclusive
+                with ``batch_size``, ``shuffle``, ``sampler``, and ``drop_last``.
+                Defaults to ``None``.
+            pin_memory: Whether to copy tensors into pinned memory before returning them.
+                If ``True``, the data loader will copy tensors into device/CUDA pinned memory
+                before returning them. If your data elements are a custom type, or `collate_fn`
+                returns a batch that is a custom type, look at ``torch.utils.data.DataLoader``
+                for examples. Defaults to ``False``.
+            timeout: Timeout, in seconds, for collecting a batch from worker processes.
+                Should always be non-negative and defaults to ``0``.
+            worker_init_fn: If not ``None``, this will be called on each worker subprocess
+                with the worker id (an int in ``[0, num_workers - 1]``) as input, after seeding
+                and before data loading. Defaults to ``None``.
+            multiprocessing_context: Multiprocessing context or context name used to create
+                worker processes.
+            prefetch_factor: Number of batches loaded in advance by each worker.
+                For example, ``2`` means there will be a total of ``2 * num_workers`` batches
+                prefetched across all workers. The default value depends on the set value
+                for num_workers. If ``num_workers=0``, defaults to ``None``.
+                If ``num_workers > 0``, defaults to ``2``.
+            in_order: If ``True``, batches are returned in first-in, first-out order when
+                ``num_workers > 0``. Defaults to ``True``.
+    """
+
     def __init__(
         self,
         dataset: Dataset,
         batch_size: int = 1,
         shuffle: bool | None = False,
         sample_full_hypergraph: bool = False,
+        drop_last: bool = False,
+        num_workers: int = 0,
+        persistent_workers: bool = False,
         collate_fn: Callable[[list[HData]], HData] | None = None,
         generator: Generator | None = None,
         **kwargs,
@@ -26,6 +82,9 @@ class DataLoader(TorchDataLoader):
             shuffle=shuffle,
             collate_fn=self.collate if collate_fn is None else collate_fn,
             generator=generator,
+            num_workers=num_workers,
+            persistent_workers=persistent_workers,
+            drop_last=drop_last,
             **kwargs,
         )
 

--- a/hyperbench/data/negative_sampler.py
+++ b/hyperbench/data/negative_sampler.py
@@ -16,7 +16,7 @@ class NegativeSampler(ABC):
     """
     Abstract base class for negative samplers.
 
-    Args:
+    Attributes:
         return_0based_negatives:
             - If ``True``, the negative samples returned by the ``sample`` method
                 will have 0-based node and hyperedge IDs.

--- a/hyperbench/data/negative_sampling_scheduler.py
+++ b/hyperbench/data/negative_sampling_scheduler.py
@@ -21,7 +21,7 @@ class NegativeSamplingScheduler:
     unnecessary sampling when the schedule dictates that negatives should only be generated at
     certain intervals.
 
-    Args:
+    Attributes:
         negative_sampler: An instance of a ``NegativeSampler`` that defines how to sample negatives.
         negative_sampling_schedule: Literal string specifying the schedule for sampling negatives.
         negative_sampling_every_n: An integer specifying the interval for sampling negatives

--- a/hyperbench/data/sampler.py
+++ b/hyperbench/data/sampler.py
@@ -12,6 +12,10 @@ class SamplingStrategy(Enum):
 
 
 class BaseSampler(ABC):
+    """
+    Abstract base class for sampling from an HData instance.
+    """
+
     @abstractmethod
     def sample(self, index: int | list[int], hdata: HData) -> HData:
         """

--- a/hyperbench/data/supported_datasets.py
+++ b/hyperbench/data/supported_datasets.py
@@ -12,7 +12,7 @@ class _PreloadedDataset(Dataset):
     Subclasses should specify the ``DATASET_NAME`` class variable. The dataset will be saved on
     disk after the first load.
 
-    Args:
+    Attributes:
         hdata: Optional HData object. If ``None``, the dataset will be loaded using
             the ``DATASET_NAME``.
         sampling_strategy: The sampling strategy to use for this dataset.

--- a/hyperbench/hlp/common.py
+++ b/hyperbench/hlp/common.py
@@ -13,7 +13,7 @@ class HlpModule(L.LightningModule):
     """
     A LightningModule for HLP models with optional negative sampling.
 
-    Args:
+    Attributes:
         encoder: Optional encoder module. Defaults to ``None`` as not
             all HLP model will use an encoder.
         decoder: Decoder module to use to predict whether hyperedges are positive or negative.

--- a/hyperbench/hlp/common_neighbors_hlp.py
+++ b/hyperbench/hlp/common_neighbors_hlp.py
@@ -15,7 +15,7 @@ class CommonNeighborsHlpModule(HlpModule):
     """
     A LightningModule for the CommonNeighbors model with optional negative sampling.
 
-    Args:
+    Attributes:
         aggregation: The aggregation method for common neighbors ("mean", "min", or "sum").
         decoder: An optional decoder module. Defaults to `CommonNeighbors`.
         loss_fn: An optional loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/gcn_hlp.py
+++ b/hyperbench/hlp/gcn_hlp.py
@@ -57,7 +57,7 @@ class GCNHlpModule(HlpModule):
     Uses a graph reduction of the input hypergraph to run GCN over nodes,
     aggregates node embeddings per hyperedge, and scores each hyperedge with a linear decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the GCN encoder.
         aggregation: Method to aggregate node embeddings per hyperedge. Defaults to ``"mean"``.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/hgnn_hlp.py
+++ b/hyperbench/hlp/hgnn_hlp.py
@@ -39,7 +39,7 @@ class HGNNHlpModule(HlpModule):
     spectral hypergraph convolution, aggregates them per hyperedge,
     and scores each hyperedge with a linear decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the HGNN encoder.
         aggregation: Method to aggregate node embeddings per hyperedge. Defaults to ``"mean"``.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/hgnnp_hlp.py
+++ b/hyperbench/hlp/hgnnp_hlp.py
@@ -39,7 +39,7 @@ class HGNNPHlpModule(HlpModule):
     row-stochastic hypergraph convolution, aggregates them per hyperedge,
     and scores each hyperedge with a linear decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the HGNN+ encoder.
         aggregation: Method to aggregate node embeddings per hyperedge. Defaults to ``"mean"``.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/hnhn_hlp.py
+++ b/hyperbench/hlp/hnhn_hlp.py
@@ -39,7 +39,7 @@ class HNHNHlpModule(HlpModule):
     hyperedge neurons, aggregates them per hyperedge, and scores each
     hyperedge with a linear decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the HNHN encoder.
         aggregation: Method to aggregate node embeddings per hyperedge. Defaults to ``"mean"``.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/hypergcn_hlp.py
+++ b/hyperbench/hlp/hypergcn_hlp.py
@@ -48,7 +48,7 @@ class HyperGCNHlpModule(HlpModule):
     graph convolution on the full hypergraph, aggregates them per hyperedge,
     and scores each hyperedge with a linear decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the HyperGCN encoder.
         aggregation: Method to aggregate node embeddings per hyperedge. Defaults to ``"mean"``.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/mlp_hlp.py
+++ b/hyperbench/hlp/mlp_hlp.py
@@ -52,7 +52,7 @@ class MLPHlpModule(HlpModule):
     Uses an MLP encoder to produce node embeddings, aggregates them per hyperedge
     via mean pooling, and scores each hyperedge with a linear decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the MLP encoder.
         aggregation: Method to aggregate node embeddings per hyperedge.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/nhp_hlp.py
+++ b/hyperbench/hlp/nhp_hlp.py
@@ -38,7 +38,7 @@ class NHPHlpModule(HlpModule):
     Unlike encoder wrappers that produce reusable global node embeddings,
     NHP builds candidate-specific incidence embeddings before pooling and scoring each hyperedge.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the NHP encoder/scorer.
         loss_fn: Loss function. Defaults to `NHPRankingLoss`.
         lr: Learning rate for the optimizer. Defaults to ``0.001``.

--- a/hyperbench/hlp/node2vecgcn_hlp.py
+++ b/hyperbench/hlp/node2vecgcn_hlp.py
@@ -51,7 +51,7 @@ class Node2VecGCNHlpModule(HlpModule):
         - ``precomputed``: use node embeddings already stored in ``batch.x``.
         - ``joint``: train a Node2Vec encoder jointly with the GCN layers and hyperedge decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the Node2Vec encoder and GCN layers.
         aggregation: Method to aggregate node embeddings per hyperedge.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/node2vecslp_hlp.py
+++ b/hyperbench/hlp/node2vecslp_hlp.py
@@ -46,7 +46,7 @@ class Node2VecSLPHlpModule(HlpModule):
         - ``precomputed``: use node embeddings already stored in ``batch.x``.
         - ``joint``: train a Node2Vec encoder jointly with the hyperedge decoder.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the Node2Vec encoder.
         aggregation: Method to aggregate node embeddings per hyperedge.
         loss_fn: Loss function. Defaults to ``BCEWithLogitsLoss``.

--- a/hyperbench/hlp/villain_hlp.py
+++ b/hyperbench/hlp/villain_hlp.py
@@ -39,7 +39,7 @@ class VilLainHlpModule(HlpModule):
     """
     Feature-free VilLain Hyperedge Link Prediction module.
 
-    Args:
+    Attributes:
         encoder_config: Configuration for the VilLain encoder.
         embedding_mode: Whether to return node or hyperedge embeddings from the VilLain encoder.
         aggregation: Aggregation method to pool node embeddings into hyperedge embeddings

--- a/hyperbench/models/common_neighbors.py
+++ b/hyperbench/models/common_neighbors.py
@@ -7,6 +7,15 @@ from hyperbench.types import Neighborhood
 
 
 class CommonNeighbors(nn.Module):
+    """
+    Computes Common Neighbors scores for hyperedges.
+
+    Attributes:
+        aggregation: Method to aggregate node embeddings per hyperedge. Can be one of
+            ``"mean"``, ``"min"``, or ``"sum"``.
+        scorer: An instance of a NeighborScorer that computes the scores for hyperedges.
+    """
+
     def __init__(
         self,
         aggregation: Literal["mean", "min", "sum"],

--- a/hyperbench/models/gcn.py
+++ b/hyperbench/models/gcn.py
@@ -48,7 +48,7 @@ class GCN(nn.Module):
     """
     A reusable multi-layer GCN stack built from ``torch_geometric.nn.GCNConv``.
 
-    Args:
+    Attributes:
         in_channels: Dimension of the input node embeddings to the GCN layers.
         out_channels: Dimension of the output node embeddings from the GCN layers.
         hidden_channels: Dimension of the hidden node embeddings in the GCN layers.

--- a/hyperbench/models/hgnn.py
+++ b/hyperbench/models/hgnn.py
@@ -14,7 +14,7 @@ class HGNN(nn.Module):
         - Proposed in [Hypergraph Neural Networks](https://arxiv.org/pdf/1809.09401) (AAAI 2019).
         - Reference implementation: [Code](https://deephypergraph.readthedocs.io/en/latest/_modules/dhg/models/hypergraphs/hgnn.html#HGNN).
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         hidden_channels: The number of hidden channels.
         num_classes: The number of output channels.

--- a/hyperbench/models/hgnnp.py
+++ b/hyperbench/models/hgnnp.py
@@ -11,7 +11,7 @@ class HGNNP(nn.Module):
         - Proposed in [HGNN+: General Hypergraph Neural Networks](https://ieeexplore.ieee.org/document/9795251) paper (IEEE T-PAMI 2022).
         - Reference implementation: [Code](https://deephypergraph.readthedocs.io/en/latest/_modules/dhg/models/hypergraphs/hgnnp.html#HGNNP).
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         hidden_channels: The number of hidden channels.
         num_classes: The number of output channels.

--- a/hyperbench/models/hnhn.py
+++ b/hyperbench/models/hnhn.py
@@ -12,7 +12,7 @@ class HNHN(nn.Module):
         - Proposed in [HNHN: Hypergraph Networks with Hyperedge Neurons](https://arxiv.org/abs/2006.12278) paper.
         - Reference implementation: [Code](https://deephypergraph.readthedocs.io/en/latest/_modules/dhg/models/hypergraphs/hnhn.html#HNHN).
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         hidden_channels: The number of hidden channels.
         num_classes: The number of output channels.

--- a/hyperbench/models/hypergcn.py
+++ b/hyperbench/models/hypergcn.py
@@ -14,7 +14,7 @@ class HyperGCN(nn.Module):
         - Code of the paper: [source](https://github.com/malllabiisc/HyperGCN).
         - Reference implementation: [source](https://deephypergraph.readthedocs.io/en/latest/_modules/dhg/models/hypergraphs/hypergcn.html#HyperGCN).
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         hidden_channels: The number of hidden channels.
         num_classes: The number of classes of the classification task as HyperGCB is a

--- a/hyperbench/models/mlp.py
+++ b/hyperbench/models/mlp.py
@@ -36,7 +36,7 @@ class MLP(nn.Module):
         >>> output.shape
         ... torch.Size([10, 1])
 
-    Args:
+    Attributes:
         in_channels: Number of input features.
         out_channels: Number of output features.
         hidden_channels: Number of hidden units in each hidden layer. Required if num_layers > 1.

--- a/hyperbench/models/nhp.py
+++ b/hyperbench/models/nhp.py
@@ -37,7 +37,7 @@ class NHP(nn.Module):
         >>> scores.shape
         ... torch.Size([2])
 
-    Args:
+    Attributes:
         in_channels: Number of input features per node.
         hidden_channels: Number of hidden units in the node embeddings.
         activation_fn: Activation function to use after the linear transformations.

--- a/hyperbench/models/node2vec.py
+++ b/hyperbench/models/node2vec.py
@@ -10,7 +10,7 @@ class Node2Vec(nn.Module):
     """
     Node2Vec implementation based on ``torch_geometric.nn.Node2Vec``.
 
-    Args:
+    Attributes:
         edge_index: Edge index representing the graph structure. Size ``(2, num_edges)``.
         embedding_dim: Dimension of the node embeddings to learn.
         walk_length: Length of each random walk.
@@ -150,7 +150,7 @@ class Node2VecGCN(nn.Module):
     """
     A joint encoder that first learns Node2Vec embeddings and then refines them with GCN layers.
 
-    Args:
+    Attributes:
         node2vec_config: Model-side configuration for the internal ``Node2Vec`` encoder.
         gcn_config: Model-side configuration for the GCN stack applied to the Node2Vec embeddings.
     """

--- a/hyperbench/models/villain.py
+++ b/hyperbench/models/villain.py
@@ -23,7 +23,7 @@ class VilLain(nn.Module):
         2. Propagates them over the incidence structure.
         3. Returns averaged propagated node embeddings.
 
-    Args:
+    Attributes:
         num_nodes: Total number of trainable nodes.
         embedding_dim: Returned embedding dimension. Defaults to ``128``.
         labels_per_subspace: Number of virtual labels per subspace. Defaults to ``2``.

--- a/hyperbench/nn/aggregator.py
+++ b/hyperbench/nn/aggregator.py
@@ -12,12 +12,12 @@ class HyperedgeAggregator:
     Each node-hyperedge incidence selects one node embedding row, then reduces
     those rows per hyperedge with the requested scatter aggregation.
 
-    Args:
+    Attributes:
         hyperedge_index: Hyperedge incidence in COO format of size ``(2, num_incidences)``.
         node_embeddings: Node embedding matrix of size ``(num_nodes, num_channels)``.
         num_hyperedges: Optional explicit hyperedge count.
-            When provided, the pooled output preserves empty hyperedges that do not appear
-            in ``hyperedge_index``.
+            When provided, the pooled output preserves empty hyperedges that
+            do not appear in ``hyperedge_index``.
     """
 
     def __init__(

--- a/hyperbench/nn/conv.py
+++ b/hyperbench/nn/conv.py
@@ -10,7 +10,7 @@ class HyperGCNConv(nn.Module):
         - The HyperGCNConv layer proposed in [HyperGCN: A New Method of Training Graph Convolutional Networks on Hypergraphs](https://dl.acm.org/doi/10.5555/3454287.3454422) paper (NeurIPS 2019).
         - Reference implementation: [source](https://deephypergraph.readthedocs.io/en/latest/_modules/dhg/nn/convs/hypergraphs/hypergcn_conv.html#HyperGCNConv).
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         out_channels: The number of output channels.
         bias: If set to ``False``, the layer will not learn the bias parameter.
@@ -117,7 +117,7 @@ class HGNNConv(nn.Module):
     Unlike ``HyperGCNConv``, which uses a GCN Laplacian on a graph reduced from the hypergraph,
     ``HGNNConv`` operates entirely in hypergraph space and preserves all higher-order relationships.
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         out_channels: The number of output channels.
         bias: If set to ``False``, the layer will not learn the bias parameter.
@@ -193,7 +193,7 @@ class HGNNPConv(nn.Module):
     spectral Laplacian, ``HGNNPConv`` uses plain inverse degrees and performs
     two-stage mean aggregation: nodes -> hyperedges -> nodes.
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         out_channels: The number of output channels.
         bias: If set to ``False``, the layer will not learn the bias parameter.
@@ -257,7 +257,7 @@ class HNHNConv(nn.Module):
         - The HNHNConv layer proposed in [HNHN: Hypergraph Networks with Hyperedge Neurons](https://arxiv.org/abs/2006.12278) paper.
         - Reference implementation: [Code](https://deephypergraph.readthedocs.io/en/latest/_modules/dhg/nn/convs/hypergraphs/hnhn_conv.html#HNHNConv).
 
-    Args:
+    Attributes:
         in_channels: The number of input channels.
         out_channels: The number of output channels.
         bias: If set to ``False``, the layer will not learn the bias parameter.

--- a/hyperbench/nn/loss.py
+++ b/hyperbench/nn/loss.py
@@ -66,7 +66,7 @@ class VilLainLoss:
     The VilLain model owns message passing and accumulation over steps
     and this class owns the per-step formulas for local and global loss,
 
-    Args:
+    Attributes:
         num_subspaces: Number of virtual-label subspaces in each embedding.
         labels_per_subspace: Number of virtual labels in each subspace.
         eps: Numerical stability constant used in logarithms and cosine similarity.

--- a/hyperbench/nn/scorer.py
+++ b/hyperbench/nn/scorer.py
@@ -7,6 +7,10 @@ from hyperbench.types import Neighborhood, Hypergraph, HyperedgeIndex
 
 
 class NeighborScorer(ABC):
+    """
+    Abstract base class for neighbor scorers.
+    """
+
     @abstractmethod
     def score(
         self,
@@ -25,6 +29,14 @@ class NeighborScorer(ABC):
 
 
 class CommonNeighborsScorer(NeighborScorer):
+    """
+    Scorer for computing the Common Neighbors (CN) score for hyperedges.
+
+    Attributes:
+        aggregation: Method to aggregate node embeddings per hyperedge. Can be one of
+            ``"mean"``, ``"min"``, or ``"sum"``.
+    """
+
     __DEFAULT_SCORE = 0.0
 
     def __init__(self, aggregation: Literal["mean", "min", "sum"]) -> None:

--- a/hyperbench/tests/data/loader_test.py
+++ b/hyperbench/tests/data/loader_test.py
@@ -85,13 +85,42 @@ def test_initialization_with_default_params(mock_dataset_single_sample):
 
 
 def test_initialization_with_custom_params(mock_dataset_single_sample):
-    loader = DataLoader(mock_dataset_single_sample, batch_size=4, shuffle=True, num_workers=0)
+    loader = DataLoader(
+        mock_dataset_single_sample,
+        batch_size=4,
+        shuffle=True,
+        drop_last=True,
+        num_workers=0,
+        persistent_workers=False,
+        in_order=False,
+    )
 
     assert loader.batch_size == 4
     assert loader.dataset == mock_dataset_single_sample
-
-    # num_workers is used to test that kwargs are passed correctly
     assert loader.num_workers == 0
+    assert loader.persistent_workers is False
+    assert loader.drop_last is True
+
+    # in_order is used to test that kwargs are passed correctly
+    assert loader.in_order is False
+
+
+@pytest.mark.parametrize(
+    "sample_full_hypergraph, expected_batch_size",
+    [
+        pytest.param(True, 3, id="sample_full_hypergraph=True"),
+        pytest.param(False, 1, id="sample_full_hypergraph=False"),
+    ],
+)
+def test_initialization_with_sample_full_hypergraph(
+    sample_full_hypergraph,
+    expected_batch_size,
+    mock_dataset_single_sample,
+):
+    loader = DataLoader(mock_dataset_single_sample, sample_full_hypergraph=sample_full_hypergraph)
+
+    assert loader.batch_size == expected_batch_size
+    assert loader.dataset == mock_dataset_single_sample
 
 
 def test_initialization_uses_collate_fn_arg_when_provided(mock_dataset_single_sample):

--- a/hyperbench/train/latex_logger.py
+++ b/hyperbench/train/latex_logger.py
@@ -91,7 +91,7 @@ class LaTexTableLogger(Logger):
     This means the file is progressively updated as models finish training/testing,
     so you can open it mid-run to see partial results.
 
-    Args:
+    Attributes:
         save_dir: Base directory where the comparison/ subfolder will be created.
         model_name: The model's full name (e.g., "mlp:mean").
         experiment_name: Shared key that groups all models in the same experiment.

--- a/hyperbench/train/markdown_logger.py
+++ b/hyperbench/train/markdown_logger.py
@@ -8,7 +8,8 @@ from hyperbench.utils import MARKDOWN_CHARACTER_ESCAPE_TABLE, escape, validate_i
 
 
 class MarkdownTableLogger(Logger):
-    """A Lightning Logger that accumulates metrics and writes a markdown comparison table.
+    """
+    A Lightning Logger that accumulates metrics and writes a markdown comparison table.
 
     Multiple instances (one per model) share a class-level store keyed by experiment_name.
     Every time finalize() is called (after fit() or test() for each model), the current
@@ -18,7 +19,7 @@ class MarkdownTableLogger(Logger):
     This means the file is progressively updated as models finish training/testing,
     so partial results are available while running.
 
-    Args:
+    Attributes:
         save_dir: Base directory where the comparison/ subfolder will be created.
         model_name: The model's full name (e.g., "mlp:mean").
         experiment_name: Shared key that groups all models in the same experiment.

--- a/hyperbench/train/trainer.py
+++ b/hyperbench/train/trainer.py
@@ -9,7 +9,7 @@ import lightning as L
 import torch
 
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from collections.abc import Iterable, Mapping
 from lightning.pytorch.accelerators import Accelerator
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint
@@ -28,54 +28,41 @@ class MultiModelTrainer:
     """
     A trainer class to handle training multiple models with individual trainers.
 
-    Args:
+    Attributes:
         model_configs: A list of ModelConfig objects, each containing a model and its
             associated trainer (if any).
-
         experiment_name: Name for this experiment run's log directory. When ``None`` (default),
             auto-increments as ``experiment_0``, ``experiment_1``, etc. under
             the log root directory. Only used when ``logger`` is not provided.
-
         accelerator: Supports passing different accelerator types
-            ("cpu", "gpu", "tpu", "hpu", "mps", "auto")
-            as well as custom accelerator instances.
-
+            ("cpu", "gpu", "tpu", "hpu", "mps", "auto") as well as custom accelerator instances.
         devices: The devices to use. Can be set to a positive number (int or str), a
             sequence of device indices (list or str), the value ``-1`` to indicate all available
             devices should be used, or ``"auto"`` for automatic selection based on the chosen
             accelerator. Defaults to ``"auto"``.
-
         test_devices: Optional device configuration for automatically-created test trainers.
             When set, ``test_all`` uses a separate Trainer with the same Trainer parameters as
             training except for ``devices``. This is useful for running distributed training
             but single-device testing, e.g. ``test_devices=1``. Defaults to ``None``, which makes
             testing use the fit trainer unless a ``ModelConfig.test_trainer`` is provided.
-
         strategy: Supports different training strategies with aliases as well custom strategies.
             Defaults to ``"auto"``.
-
         num_nodes: Number of GPU nodes for distributed training.
             Defaults to ``1``.
-
         precision: Double precision (64, '64' or '64-true'),
             full precision (32, '32' or '32-true'), 16bit mixed precision (16, '16', '16-mixed') or
             bfloat16 mixed precision ('bf16', 'bf16-mixed').
             Can be used on CPU, GPU, TPUs, or HPUs.
             Defaults to ``'32-true'``.
-
         max_epochs: Stop training once this number of epochs is reached. Disabled by default (None).
             If both max_epochs and max_steps are not specified, defaults to ``max_epochs = 1000``.
             To enable infinite training, set ``max_epochs = -1``.
-
         min_epochs: Force training for at least these many epochs. Disabled by default (None).
-
         max_steps: Stop training after this number of steps. Disabled by default (-1).
             If ``max_steps = -1`` and ``max_epochs = None``, will default to ``max_epochs = 1000``.
             To enable infinite training, set ``max_epochs`` to ``-1``.
-
         min_steps: Force training for at least these number of steps.
             Disabled by default (``None``).
-
         check_val_every_n_epoch: Perform a validation loop after every `N` training epochs.
             If ``None``, validation will be done solely based on the number of training batches,
             requiring ``val_check_interval`` to be an integer value. When used together with a
@@ -85,50 +72,38 @@ class MultiModelTrainer:
             if it elapses during a multiple-N epoch, validation runs after the current batch.
             For ``None`` or ``1`` cases, the time-based behavior of ``val_check_interval``
             applies without additional alignment. Defaults to ``1``.
-
         logger: Logger (or iterable collection of loggers) for experiment tracking. A ``True``
             value uses the default ``TensorBoardLogger`` if it is installed,
             otherwise ``CSVLogger``. ``False`` will disable logging. If multiple loggers are
             provided, local files (checkpoints, profiler traces, etc.) are saved in the ``log_dir``
             of the first logger. Defaults to ``True``.
-
         default_root_dir: Default path for logs and weights when no logger/ckpt_callback passed.
             Defaults to ``os.getcwd()``.
             Can be remote file paths such as `s3://mybucket/path` or 'hdfs://path/'
-
         enable_autolog_hparams: Whether to log hyperparameters at the start of a run.
             Defaults to ``True``.
-
         log_every_n_steps: How often to log within steps.
             Defaults to ``50``.
-
         profiler: To profile individual steps during training and assist in identifying bottlenecks.
             Defaults to ``None``.
-
         fast_dev_run: Runs n if set to ``n`` (int) else 1 if set to ``True`` batch(es)
             of train, val and test to find any bugs (ie: a sort of unit test).
             Defaults to ``False``.
-
         enable_checkpointing: If ``True``, enable checkpointing.
             It will configure a default ModelCheckpoint callback if there is no user-defined
                 ModelCheckpoint in :paramref:`~hyperbench.train.MultiModelTrainer.callbacks`.
             Defaults to ``True``.
-
         enable_progress_bar: Whether to enable the progress bar by default.
             Defaults to ``True``.
-
         enable_model_summary: Whether to enable model summarization by default.
             Defaults to ``True``.
-
         callbacks: Add a callback or list of callbacks.
             Defaults to ``None``.
-
         checkpoint_callback_kwargs: Keyword arguments passed to the default
             ``ModelCheckpoint`` callback when checkpointing is enabled and no
             user-defined ``ModelCheckpoint`` is provided. Pass ``dirpath`` to
             override the default checkpoint directory.
             Defaults to ``None``.
-
         auto_start_tensorboard: When ``True`` and tensorboard is installed, automatically starts
             a TensorBoard server pointing at the experiment log directory.
             Using this option requires that TensorBoard is installed in the environment and moves
@@ -137,14 +112,38 @@ class MultiModelTrainer:
             or when the object is garbage collected). Enable `auto_wait` to keep the server alive
             after training completes so you can inspect results before the trainer is finalized.
             Defaults to ``False``.
-
         tensorboard_port: Port for the auto-launched TensorBoard server.
             Defaults to ``6006``.
-
         auto_wait: When ``True`` and a TensorBoard server is running, automatically calls
-            :meth:`wait` inside `finalize` before terminating the server, so the user
+            ``wait`` inside `finalize` before terminating the server, so the user
             can inspect results before the process is stopped.
             Defaults to ``False``.
+
+        kwargs:
+            max_time: Maximum wall-clock training time. Passed to Lightning's ``Trainer``.
+            limit_train_batches: Fraction or number of training batches to use.
+            limit_val_batches: Fraction or number of validation batches to use.
+            limit_test_batches: Fraction or number of test batches to use.
+            limit_predict_batches: Fraction or number of prediction batches to use.
+            overfit_batches: Fraction or number of batches to use for overfitting checks.
+            val_check_interval: How often to run validation within a training epoch.
+            num_sanity_val_steps: Number of validation batches to run before training starts.
+            accumulate_grad_batches: Number of batches over which to accumulate gradients.
+            gradient_clip_val: Value used for gradient clipping.
+            gradient_clip_algorithm: Gradient clipping algorithm to use.
+            deterministic: Whether to enable deterministic operations, or ``"warn"``
+                to warn when deterministic execution is not available.
+            benchmark: Whether to enable cuDNN benchmarking.
+            inference_mode: Whether validation, test, and prediction loops should use
+                ``torch.inference_mode``.
+            use_distributed_sampler: Whether Lightning should inject distributed samplers for
+                distributed training.
+            detect_anomaly: Whether to enable PyTorch autograd anomaly detection.
+            barebones: Whether to disable features that may affect raw training-loop speed.
+            plugins: Lightning plugins or list of plugins to use.
+            sync_batchnorm: Whether to synchronize batch normalization across devices.
+            reload_dataloaders_every_n_epochs: How often to recreate dataloaders.
+            model_registry: Name of the Lightning model registry to use.
     """
 
     DEFAULT_BASE_LOG_DIR = "hyperbench_logs"
@@ -264,7 +263,7 @@ class MultiModelTrainer:
 
                 if should_create_test_trainer:
                     model_config.test_trainer = __trainer_for(
-                        trainer_devices=cast(list[int] | str | int, test_devices),
+                        trainer_devices=test_devices if test_devices is not None else devices,
                         model_logger=model_logger,
                         model_callbacks=model_callbacks,
                     )

--- a/hyperbench/types/graph.py
+++ b/hyperbench/types/graph.py
@@ -11,7 +11,7 @@ class Graph:
     """
     A simple graph data structure using edge list representation.
 
-    Args:
+    Attributes:
         edges: A list of edges, where each edge is represented as a list of two integers
             (source_node, destination_node).
         edge_weights: Optional list of edge weights corresponding to each edge in ``edges``.
@@ -157,7 +157,7 @@ class EdgeIndex:
         This represents a graph with edges (0, 1), (1, 0), and (2, 3).
         The number of nodes in this graph is 4 (nodes 0, 1, 2, and 3) and the number of edges is 3.
 
-    Args:
+    Attributes:
         edge_index: A tensor of shape ``(2, num_edges)`` representing the edges in the graph.
         edge_weights: Optional tensor of shape ``(num_edges,)`` containing a weight for each edge.
     """
@@ -586,18 +586,18 @@ class EdgeIndex:
     def remove_duplicate_edges(self, num_nodes: int | None = None) -> EdgeIndex:
         """
         Remove duplicate edges from the edge index.
-
         Keeps the tensor contiguous in memory.
-                Args:
-                    num_nodes: The number of nodes in the graph. If ``None``, it will be
-                        inferred from ``self.num_nodes``.
-                        This parameter is important when ``edge_index`` does not contain all nodes
-                        (e.g., some nodes are isolated and have no edges or have been removed),
-                        as it ensures that the resulting Laplacian matrix has the correct size
-                        and includes all nodes. For instance, for self-loops.
 
-                Returns:
-                    edge_index: This `EdgeIndex` instance with duplicate edges removed.
+        Args:
+            num_nodes: The number of nodes in the graph. If ``None``, it will be
+                inferred from ``self.num_nodes``.
+                This parameter is important when ``edge_index`` does not contain all nodes
+                (e.g., some nodes are isolated and have no edges or have been removed),
+                as it ensures that the resulting Laplacian matrix has the correct size
+                and includes all nodes. For instance, for self-loops.
+
+        Returns:
+            edge_index: This `EdgeIndex` instance with duplicate edges removed.
         """
         num_nodes = self.num_nodes if num_nodes is None else num_nodes
         self.__validate_num_nodes(num_nodes)

--- a/hyperbench/types/model.py
+++ b/hyperbench/types/model.py
@@ -17,7 +17,7 @@ class ModelConfig:
     """
     A class representing the configuration of a model for training.
 
-    Args:
+    Attributes:
         name: The name of the model.
         version: The version of the model.
         model: a LightningModule instance.


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Add docstrings for MultiModelTrainer and DataLoader.
- Fix `ty` warning in MultiModelTrainer.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make format`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
