### PR TITLE
refactor: rename Default* splitters to Hyperedge* splitters

### DIFF
--- a/hypertorch/data/__init__.py
+++ b/hypertorch/data/__init__.py
@@ -64,8 +64,8 @@ from .sampler import (
 )
 
 from .splitter import (
-    DefaultDatasetSplitter,
-    DefaultHDataSplitter,
+    HyperedgeDatasetSplitter,
+    HyperedgeHDataSplitter,
     HyperedgeIDSplitter,
     Splitter,
 )
@@ -83,8 +83,6 @@ __all__ = [
     "DBLPDataset",
     "DataLoader",
     "Dataset",
-    "DefaultDatasetSplitter",
-    "DefaultHDataSplitter",
     "EmailEnronDataset",
     "EmailW3CDataset",
     "EnrichmentMode",
@@ -95,7 +93,9 @@ __all__ = [
     "HIFLoader",
     "HIFProcessor",
     "HyperedgeAttrsEnricher",
+    "HyperedgeDatasetSplitter",
     "HyperedgeEnricher",
+    "HyperedgeHDataSplitter",
     "HyperedgeIDSplitter",
     "HyperedgeSampler",
     "HyperedgeWeightsEnricher",

--- a/hypertorch/data/dataset.py
+++ b/hypertorch/data/dataset.py
@@ -13,7 +13,7 @@ from hypertorch.utils import (
 
 from hypertorch.data.hif import HIFLoader, HIFProcessor
 from hypertorch.data.sampler import BaseSampler, SamplingStrategy, create_sampler_from_strategy
-from hypertorch.data.splitter import DefaultDatasetSplitter, Splitter
+from hypertorch.data.splitter import HyperedgeDatasetSplitter, Splitter
 
 if TYPE_CHECKING:
     from hypertorch.data import (
@@ -376,7 +376,7 @@ class Dataset(TorchDataset):
         if ratios is None:
             raise ValueError("'ratios' must be provided when no custom 'splitter' is provided.")
 
-        splits, _ = DefaultDatasetSplitter(
+        splits, _ = HyperedgeDatasetSplitter(
             node_space_setting=node_space_setting,
             shuffle=shuffle,
             seed=seed,
@@ -436,15 +436,16 @@ class Dataset(TorchDataset):
                 is set to ``False``. Defaults to ``None``.
 
         Returns:
-            datasets_and_ratios: A tuple containing the split datasets and their
-                final hyperedge-count ratios.
+            datasets: List of Dataset instances, one per split, each with contiguous IDs.
+            final_ratios: List of floats representing the actual ratios of hyperedges
+                in each split after splitting and any requested rebalancing.
 
         Raises:
             ValueError: If ratios do not sum to ``1.0``, a final split has zero
                 hyperedges, or a requested transductive train-cover split cannot
                 cover the full node space.
         """
-        return DefaultDatasetSplitter(
+        return HyperedgeDatasetSplitter(
             node_space_setting=node_space_setting,
             shuffle=shuffle,
             seed=seed,

--- a/hypertorch/data/splitter.py
+++ b/hypertorch/data/splitter.py
@@ -47,7 +47,7 @@ class Splitter(ABC, Generic[_ToSplitType, _SplitResultType]):
         pass
 
 
-class DefaultDatasetSplitter(Splitter["Dataset", tuple[list["Dataset"], list[float]]]):
+class HyperedgeDatasetSplitter(Splitter["Dataset", tuple[list["Dataset"], list[float]]]):
     """
     Split a dataset by hyperedges and materialize dataset partitions.
 
@@ -144,7 +144,7 @@ class DefaultDatasetSplitter(Splitter["Dataset", tuple[list["Dataset"], list[flo
                 if is_transductive_setting(self.node_space_setting) and split_num == train_split_idx
                 else "inductive"
             )
-            split_hdata = DefaultHDataSplitter(node_space_setting=split_node_space_setting).split(
+            split_hdata = HyperedgeHDataSplitter(node_space_setting=split_node_space_setting).split(
                 to_split=hdata,
                 split_hyperedge_ids=split_hyperedge_ids,
             )
@@ -179,7 +179,7 @@ class DefaultDatasetSplitter(Splitter["Dataset", tuple[list["Dataset"], list[flo
         validate_is_between("train_split_idx", train_split_idx, 0, len(ratios) - 1)
 
 
-class DefaultHDataSplitter(Splitter["HData", "HData"]):
+class HyperedgeHDataSplitter(Splitter["HData", "HData"]):
     """
     Materialize an `HData` split from explicit hyperedge IDs.
 

--- a/hypertorch/tests/data/dataset_test.py
+++ b/hypertorch/tests/data/dataset_test.py
@@ -8,7 +8,7 @@ from hypertorch.types import HData
 from hypertorch.data import (
     AlgebraDataset,
     Dataset,
-    DefaultDatasetSplitter,
+    HyperedgeDatasetSplitter,
     HIFLoader,
     HyperedgeEnricher,
     NegativeSampler,
@@ -1559,7 +1559,7 @@ def test_default_dataset_splitter_returns_dataset_instances_with_sampling_strate
     )
     dataset = Dataset.from_hdata(hdata, sampling_strategy=strategy)
 
-    splits, final_ratios = DefaultDatasetSplitter(node_space_setting="inductive").split(
+    splits, final_ratios = HyperedgeDatasetSplitter(node_space_setting="inductive").split(
         to_split=dataset, ratios=[0.5, 0.5]
     )
 

--- a/hypertorch/tests/data/splitter_test.py
+++ b/hypertorch/tests/data/splitter_test.py
@@ -5,8 +5,8 @@ import re
 from typing import Any, cast
 from hypertorch.data import (
     Dataset,
-    DefaultDatasetSplitter,
-    DefaultHDataSplitter,
+    HyperedgeDatasetSplitter,
+    HyperedgeHDataSplitter,
     HyperedgeIDSplitter,
     SamplingStrategy,
     Splitter,
@@ -32,14 +32,14 @@ def test_splitter_is_abstract():
         Splitter()
 
 
-def test_default_hdata_splitter_materializes_inductive_split():
+def test_hyperedge_hdata_splitter_materializes_inductive_split():
     hdata = HData(
         x=torch.tensor([[10.0], [20.0], [30.0], [40.0]], dtype=torch.float),
         hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long),
         y=torch.tensor([1.0, 0.0], dtype=torch.float),
     )
 
-    split_hdata = DefaultHDataSplitter(node_space_setting="inductive").split(
+    split_hdata = HyperedgeHDataSplitter(node_space_setting="inductive").split(
         to_split=hdata, split_hyperedge_ids=torch.tensor([1], dtype=torch.long)
     )
 
@@ -52,7 +52,7 @@ def test_default_hdata_splitter_materializes_inductive_split():
     assert torch.equal(split_hdata.y, torch.tensor([0.0], dtype=torch.float))
 
 
-def test_default_hdata_splitter_materializes_transductive_split():
+def test_hyperedge_hdata_splitter_materializes_transductive_split():
     hdata = HData(
         x=torch.tensor([[10.0], [20.0], [30.0], [40.0]], dtype=torch.float),
         hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long),
@@ -60,7 +60,7 @@ def test_default_hdata_splitter_materializes_transductive_split():
         y=torch.tensor([1.0, 0.0], dtype=torch.float),
     )
 
-    split_hdata = DefaultHDataSplitter(node_space_setting="transductive").split(
+    split_hdata = HyperedgeHDataSplitter(node_space_setting="transductive").split(
         to_split=hdata, split_hyperedge_ids=torch.tensor([1], dtype=torch.long)
     )
 
@@ -76,14 +76,14 @@ def test_default_hdata_splitter_materializes_transductive_split():
     assert torch.equal(split_hdata.y, torch.tensor([0.0], dtype=torch.float))
 
 
-def test_default_dataset_splitter_materializes_datasets_and_final_ratios():
+def test_hyperedge_dataset_splitter_materializes_datasets_and_final_ratios():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float32).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long),
     )
     dataset = Dataset.from_hdata(hdata, sampling_strategy=SamplingStrategy.NODE)
 
-    split_datasets, final_ratios = DefaultDatasetSplitter(node_space_setting="inductive").split(
+    split_datasets, final_ratios = HyperedgeDatasetSplitter(node_space_setting="inductive").split(
         to_split=dataset, ratios=[0.5, 0.5]
     )
 
@@ -95,23 +95,23 @@ def test_default_dataset_splitter_materializes_datasets_and_final_ratios():
     ]
 
 
-def test_default_dataset_splitter_uses_train_split_idx_for_transductive_split():
+def test_hyperedge_dataset_splitter_uses_train_split_idx_for_transductive_split():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float32).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long),
     )
     dataset = Dataset.from_hdata(hdata)
 
-    split_datasets, final_ratios = DefaultDatasetSplitter(node_space_setting="transductive").split(
-        to_split=dataset, ratios=[0.5, 0.5], train_split_idx=1
-    )
+    split_datasets, final_ratios = HyperedgeDatasetSplitter(
+        node_space_setting="transductive"
+    ).split(to_split=dataset, ratios=[0.5, 0.5], train_split_idx=1)
 
     assert final_ratios == [0.5, 0.5]
     assert split_datasets[0].hdata.num_nodes == 2
     assert split_datasets[1].hdata.num_nodes == hdata.num_nodes
 
 
-def test_default_dataset_splitter_split_raises_when_train_split_idx_is_out_of_bounds():
+def test_hyperedge_dataset_splitter_split_raises_when_train_split_idx_is_out_of_bounds():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3, 0], [0, 1, 2, 3, 4]], dtype=torch.long),
@@ -121,12 +121,12 @@ def test_default_dataset_splitter_split_raises_when_train_split_idx_is_out_of_bo
     with pytest.raises(
         ValueError, match=re.escape("'train_split_idx' must be between 0 and 1 inclusive, got 2.")
     ):
-        DefaultDatasetSplitter(node_space_setting="transductive").split(
+        HyperedgeDatasetSplitter(node_space_setting="transductive").split(
             to_split=dataset, ratios=[0.5, 0.5], train_split_idx=2
         )
 
 
-def test_default_dataset_splitter_split_raises_when_train_split_idx_provided_but_not_transductive():
+def test_hyperedge_dataset_splitter_split_raises_when_train_split_idx_provided_not_transductive():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3, 0], [0, 1, 2, 3, 4]], dtype=torch.long),
@@ -139,22 +139,24 @@ def test_default_dataset_splitter_split_raises_when_train_split_idx_provided_but
             "'train_split_idx' is only relevant when 'node_space_setting' is 'transductive'"
         ),
     ):
-        DefaultDatasetSplitter(node_space_setting="inductive").split(
+        HyperedgeDatasetSplitter(node_space_setting="inductive").split(
             to_split=dataset, ratios=[0.5, 0.5], train_split_idx=1
         )
 
 
-def test_default_dataset_splitter_raises_when_ratios_do_not_sum_to_one(mock_hdata_five_hyperedges):
+def test_hyperedge_dataset_splitter_raises_when_ratios_do_not_sum_to_one(
+    mock_hdata_five_hyperedges,
+):
     dataset = Dataset.from_hdata(mock_hdata_five_hyperedges)
 
     with pytest.raises(
         ValueError,
         match=re.escape("'ratios' must sum to 1.0"),
     ):
-        DefaultDatasetSplitter().split(to_split=dataset, ratios=[0.5, 0.25])
+        HyperedgeDatasetSplitter().split(to_split=dataset, ratios=[0.5, 0.25])
 
 
-def test_default_dataset_splitter_rebalances_first_split_to_cover_all_nodes():
+def test_hyperedge_dataset_splitter_rebalances_first_split_to_cover_all_nodes():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3, 0], [0, 1, 2, 3, 4]], dtype=torch.long),
@@ -163,7 +165,7 @@ def test_default_dataset_splitter_rebalances_first_split_to_cover_all_nodes():
     )
     dataset = Dataset.from_hdata(hdata)
 
-    split_datasets, _ = DefaultDatasetSplitter().split(
+    split_datasets, _ = HyperedgeDatasetSplitter().split(
         to_split=dataset, ratios=[0.75, 0.25], cover_all_nodes_in_train_split=True
     )
 
@@ -187,14 +189,14 @@ def test_default_dataset_splitter_rebalances_first_split_to_cover_all_nodes():
     assert torch.equal(split_labels.sort().values, hdata.y)
 
 
-def test_default_dataset_splitter_returns_final_transductive_ratios_when_train_cov_is_enabled():
+def test_hyperedge_dataset_splitter_returns_final_transductive_ratios_when_train_cov_is_enabled():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3, 0], [0, 1, 2, 3, 4]], dtype=torch.long),
     )
     dataset = Dataset.from_hdata(hdata)
 
-    split_datasets, final_ratios = DefaultDatasetSplitter().split(
+    split_datasets, final_ratios = HyperedgeDatasetSplitter().split(
         to_split=dataset, ratios=[0.75, 0.25], cover_all_nodes_in_train_split=True
     )
 
@@ -202,7 +204,7 @@ def test_default_dataset_splitter_returns_final_transductive_ratios_when_train_c
     assert final_ratios == pytest.approx([0.8, 0.2])
 
 
-def test_default_dataset_splitter_keeps_ratios_when_train_covers_all_nodes():
+def test_hyperedge_dataset_splitter_keeps_ratios_when_train_covers_all_nodes():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor(
@@ -215,7 +217,7 @@ def test_default_dataset_splitter_keeps_ratios_when_train_covers_all_nodes():
     )
     dataset = Dataset.from_hdata(hdata)
 
-    split_datasets, final_ratios = DefaultDatasetSplitter().split(
+    split_datasets, final_ratios = HyperedgeDatasetSplitter().split(
         to_split=dataset, ratios=[0.5, 0.5], cover_all_nodes_in_train_split=True
     )
 
@@ -227,7 +229,7 @@ def test_default_dataset_splitter_keeps_ratios_when_train_covers_all_nodes():
     )
 
 
-def test_default_dataset_splitter_raises_when_rebalancing_empties_split():
+def test_hyperedge_dataset_splitter_raises_when_rebalancing_empties_split():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long),
@@ -238,12 +240,12 @@ def test_default_dataset_splitter_raises_when_rebalancing_empties_split():
         ValueError,
         match=re.escape("Splitting produced splits"),
     ):
-        DefaultDatasetSplitter().split(
+        HyperedgeDatasetSplitter().split(
             to_split=dataset, ratios=[0.75, 0.25], cover_all_nodes_in_train_split=True
         )
 
 
-def test_default_dataset_splitter_raises_when_node_is_missing_from_all_hyperedges():
+def test_hyperedge_dataset_splitter_raises_when_node_is_missing_from_all_hyperedges():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),
         hyperedge_index=torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long),
@@ -257,7 +259,7 @@ def test_default_dataset_splitter_raises_when_node_is_missing_from_all_hyperedge
             "node ids do not appear in any hyperedge: [3]."
         ),
     ):
-        DefaultDatasetSplitter().split(
+        HyperedgeDatasetSplitter().split(
             to_split=dataset, ratios=[0.5, 0.5], cover_all_nodes_in_train_split=True
         )
 

--- a/hypertorch/tests/types/hdata_test.py
+++ b/hypertorch/tests/types/hdata_test.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 from typing import Any, cast
 from hypertorch import utils
 from hypertorch.data import (
-    DefaultHDataSplitter,
     HyperedgeEnricher,
     NegativeSampler,
     NodeEnricher,
@@ -1053,21 +1052,6 @@ def test_split_transductive_counts(
     assert result.num_nodes == expected_num_nodes
     assert result.num_hyperedges == expected_num_hyperedges
     assert torch.equal(result.hyperedge_index, expected_hyperedge_index)
-
-
-def test_default_hdata_splitter_materializes_explicit_hyperedge_ids():
-    x = torch.randn(4, 2, dtype=torch.float)
-    hyperedge_index = torch.tensor([[0, 1, 2, 2, 3], [0, 0, 0, 1, 1]], dtype=torch.long)
-    hdata = HData(x=x, hyperedge_index=hyperedge_index)
-
-    result = DefaultHDataSplitter(node_space_setting="inductive").split(
-        to_split=hdata, split_hyperedge_ids=torch.tensor([1], dtype=torch.long)
-    )
-
-    assert result.num_nodes == 2
-    assert result.num_hyperedges == 1
-    assert torch.equal(result.hyperedge_index, torch.tensor([[0, 1], [0, 0]], dtype=torch.long))
-    assert torch.equal(result.x, x[torch.tensor([2, 3], dtype=torch.long)])
 
 
 def test_split_delegates_to_custom_hdata_splitter():

--- a/hypertorch/types/hdata.py
+++ b/hypertorch/types/hdata.py
@@ -396,9 +396,9 @@ class HData:
                 "'split_hyperedge_ids' must be provided when 'splitter' is not provided."
             )
 
-        from hypertorch.data.splitter import DefaultHDataSplitter
+        from hypertorch.data.splitter import HyperedgeHDataSplitter
 
-        return DefaultHDataSplitter(node_space_setting=node_space_setting).split(
+        return HyperedgeHDataSplitter(node_space_setting=node_space_setting).split(
             to_split=hdata,
             split_hyperedge_ids=split_hyperedge_ids,
         )

--- a/zensical.toml
+++ b/zensical.toml
@@ -6,7 +6,7 @@ site_name = "©HyperTorch Documentation"
 site_description = "Documentation for HyperTorch"
 site_author = "Hypernetwork Research Group"
 site_url = "https://hypernetwork-research-group.github.io/hypertorch"
-repo_name = "hypernetwork-research-group/hypertorch"
+repo_name = "HyperTorch"
 repo_url = "https://github.com/hypernetwork-research-group/hypertorch"
 copyright = """
 Copyright &copy; 2026 The authors
@@ -117,7 +117,7 @@ pygments_lang_class = true
 [project.markdown_extensions.pymdownx.smartsymbols]
 [project.markdown_extensions.pymdownx.superfences]
 custom_fences = [
-  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
 ]
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Rename Default* splitters to Hyperedge* splitters.
- Change repo name in documentation.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make format`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
