### PR TITLE
fix: collate masks and labels when sample_full_hypergraph set

### DIFF
--- a/examples/hyperlink_prediction/villain.py
+++ b/examples/hyperlink_prediction/villain.py
@@ -111,7 +111,8 @@ if __name__ == "__main__":
             "generation_steps": 28,
             "tau": 1.0,
             "eps": 1e-10,
-            "villain_loss_weight": 1.0,
+            # 40% weight on the VilLain loss, 60% weight on the classifier loss
+            "villain_loss_weight": 0.4,
             # Transductive splits keep the full node space.
             "num_nodes": dataset.hdata.num_nodes,
         },

--- a/examples/node_classification/villain.py
+++ b/examples/node_classification/villain.py
@@ -1,6 +1,6 @@
 from torchmetrics import MetricCollection
 from torchmetrics.classification import MulticlassAUROC, MulticlassAccuracy, MulticlassF1Score
-from hypertorch.data import AlgebraDataset, DataLoader
+from hypertorch.data import CoraDataset, DataLoader
 from hypertorch.nc import VilLainNcModule
 from hypertorch.train import MultiModelTrainer
 from hypertorch.types import ModelConfig
@@ -21,7 +21,7 @@ if __name__ == "__main__":
 
     print("Loading and preparing dataset...")
 
-    dataset = AlgebraDataset(sampling_strategy="node", task="node-classification")
+    dataset = CoraDataset(sampling_strategy="node", task="node-classification")
     dataset.hdata.y = node_labels_from_node_degrees(
         node_incidences=dataset.hdata.hyperedge_index[0],
         num_nodes=dataset.hdata.num_nodes,
@@ -73,7 +73,8 @@ if __name__ == "__main__":
             "generation_steps": 28,
             "tau": 1.0,
             "eps": 1e-10,
-            "villain_loss_weight": 1.0,
+            # 40% weight on the VilLain loss, 60% weight on the classifier loss
+            "villain_loss_weight": 0.4,
             # Transductive splits keep global node IDs available for the full node space.
             "num_nodes": dataset.hdata.num_nodes,
         },

--- a/hypertorch/data/dataset.py
+++ b/hypertorch/data/dataset.py
@@ -69,6 +69,25 @@ class Dataset(TorchDataset):
         """
         Return the number of sampleable items in the dataset.
 
+        Note:
+            The length of the dataset is determined by the sampling strategy. If the strategy is
+            based on nodes, the length corresponds to the number of sampleable nodes.
+            If the strategy is based on hyperedges, the length corresponds to the
+            number of sampleable hyperedges.
+
+        Examples:
+            Assuming `sampling_strategy="node"`:
+            >>> len(original_dataset)  # Returns the number of total nodes in the dataset
+            >>> len(sampled_dataset)   # Returns the number of sampled nodes in the dataset
+            ...                        # If sampled nodes are fewer than total nodes,
+            ...                        # this will be less than the original dataset length
+
+            Assuming `sampling_strategy="hyperedge"`:
+            >>> len(original_dataset)  # Returns the number of total hyperedges in the dataset
+            >>> len(sampled_dataset)   # Returns the number of sampled hyperedges in the dataset
+            ...                        # If sampled hyperedges are fewer than total hyperedges,
+            ...                        # this will be less than the original dataset length
+
         Returns:
             length: Number of sampleable nodes or hyperedges, depending on the sampling strategy.
         """

--- a/hypertorch/data/loader.py
+++ b/hypertorch/data/loader.py
@@ -145,7 +145,7 @@ class DataLoader(TorchDataLoader):
             hdata: A single `HData` object containing the collated data.
         """
         if self.__sample_full_hypergraph:
-            return self.__cached_dataset_hdata.clone().to(batch[0].device)
+            return self.__collate_full_hypergraph(batch)
 
         collated_hyperedge_index = torch.cat([data.hyperedge_index for data in batch], dim=1)
         hyperedge_index_wrapper = HyperedgeIndex(collated_hyperedge_index).remove_duplicate_edges()
@@ -195,6 +195,38 @@ class DataLoader(TorchDataLoader):
 
         return collated_hdata.to(batch[0].device)
 
+    def __collate_full_hypergraph(self, batch: list[HData]) -> HData:
+        """
+        Return the full hypergraph with target masks and labels rebuilt from the sampled batch.
+
+        The sampled HData instances identify the current training targets, while the cached
+        dataset HData provides the full hypergraph context.
+
+        Args:
+            batch: List of HData objects to collate.
+
+        Returns:
+            hdata: A single HData object containing the full hypergraph
+                with target masks and labels updated from the sampled batch.
+        """
+        hyperedge_index_wrapper = HyperedgeIndex(self.__cached_dataset_hdata.hyperedge_index)
+
+        (
+            collated_y,
+            collated_target_node_mask,
+            collated_target_hyperedge_mask,
+        ) = self.__collate_y_and_target_masks_for_task(
+            batch=batch,
+            hyperedge_index_wrapper=hyperedge_index_wrapper,
+        )
+        collated_hdata = self.__cached_dataset_hdata.clone()
+        return (
+            collated_hdata.with_y(collated_y)
+            .with_target_node_mask(collated_target_node_mask)
+            .with_target_hyperedge_mask(collated_target_hyperedge_mask)
+            .to(batch[0].device)
+        )
+
     def __collate_y_and_target_masks_for_task(
         self,
         batch: list[HData],
@@ -223,8 +255,8 @@ class DataLoader(TorchDataLoader):
             collated_target_hyperedge_mask = None
 
             target_node_ids_list = [
-                HyperedgeIndex(hdata.hyperedge_index).node_ids[hdata.target_node_mask]
-                for hdata in batch
+                HyperedgeIndex(batch_hdata.hyperedge_index).node_ids[batch_hdata.target_node_mask]
+                for batch_hdata in batch
             ]
             target_node_ids = torch.cat(target_node_ids_list, dim=0)
             collated_target_node_mask = torch.isin(node_ids, target_node_ids)

--- a/hypertorch/tests/data/loader_test.py
+++ b/hypertorch/tests/data/loader_test.py
@@ -554,6 +554,112 @@ def test_collate_sample_full_hypergraph_returns_cached_hdata(mock_dataset_single
     )
 
 
+def test_collate_sample_full_hypergraph_uses_sampled_target_node_mask():
+    x = torch.tensor(
+        [[1.0, 1.5], [2.0, 2.5], [3.0, 3.5], [4.0, 4.5]],
+        dtype=torch.float,
+    )
+    hyperedge_index = torch.tensor([[0, 1, 2, 2, 3], [0, 0, 1, 1, 1]], dtype=torch.long)
+    y = torch.tensor([10, 11, 12, 13], dtype=torch.long)
+    hdata = HData(
+        x=x,
+        hyperedge_index=hyperedge_index,
+        target_node_mask=torch.tensor([True, True, True, True], dtype=torch.bool),
+        y=y,
+        task="node-classification",
+    )
+
+    sample0 = HData(
+        x=torch.empty((0, 0), dtype=torch.float),
+        hyperedge_index=torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long),
+        target_node_mask=torch.tensor([False, True, False], dtype=torch.bool),
+        task="node-classification",
+    )
+    sample1 = HData(
+        x=torch.empty((0, 0), dtype=torch.float),
+        hyperedge_index=torch.tensor([[2, 3], [1, 1]], dtype=torch.long),
+        target_node_mask=torch.tensor([False, True], dtype=torch.bool),
+        task="node-classification",
+    )
+
+    dataset = MagicMock(spec=Dataset)
+    dataset.hdata = hdata
+    dataset.__len__.return_value = 2
+
+    loader = DataLoader(dataset, sample_full_hypergraph=True)
+    batched = loader.collate([sample0, sample1])
+
+    assert torch.equal(batched.x, x)
+    assert torch.equal(batched.hyperedge_index, hyperedge_index)
+    assert torch.equal(batched.y, y)
+    assert torch.equal(
+        batched.target_node_mask,
+        torch.tensor([False, True, False, True], dtype=torch.bool),
+    )
+
+
+def test_collate_sample_full_hypergraph_uses_sampled_target_hyperedge_mask():
+    x = torch.tensor([[1.0, 1.5], [2.0, 2.5], [3.0, 3.5], [4.0, 4.5]], dtype=torch.float)
+    hyperedge_index = torch.tensor([[0, 1, 2, 3, 0], [0, 0, 1, 1, 2]], dtype=torch.long)
+    y = torch.tensor([1.0, 0.0, 1.0], dtype=torch.float)
+    hdata = HData(
+        x=x,
+        hyperedge_index=hyperedge_index,
+        target_hyperedge_mask=torch.tensor([True, True, True], dtype=torch.bool),
+        y=y,
+        task="hyperlink-prediction",
+    )
+
+    sample0 = HData(
+        x=torch.empty((0, 0), dtype=torch.float),
+        hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long),
+        target_hyperedge_mask=torch.tensor([False, True], dtype=torch.bool),
+    )
+    sample1 = HData(
+        x=torch.empty((0, 0), dtype=torch.float),
+        hyperedge_index=torch.tensor([[0], [2]], dtype=torch.long),
+        num_hyperedges=1,
+        target_hyperedge_mask=torch.tensor([True], dtype=torch.bool),
+    )
+
+    dataset = MagicMock(spec=Dataset)
+    dataset.hdata = hdata
+    dataset.__len__.return_value = 2
+
+    loader = DataLoader(dataset, sample_full_hypergraph=True)
+    batched = loader.collate([sample0, sample1])
+
+    assert torch.equal(batched.x, x)
+    assert torch.equal(batched.hyperedge_index, hyperedge_index)
+    assert torch.equal(batched.y, y)
+    assert torch.equal(
+        batched.target_hyperedge_mask,
+        torch.tensor([False, True, True], dtype=torch.bool),
+    )
+
+
+def test_collate_sample_full_hypergraph_raises_for_unsupported_cached_task_category():
+    hdata = HData(
+        x=torch.tensor([[1.0], [2.0]], dtype=torch.float),
+        hyperedge_index=torch.tensor([[0, 1], [0, 0]], dtype=torch.long),
+    )
+    hdata.task = cast(Any, "unsupported")
+
+    sample = HData.from_hyperedge_index(torch.tensor([[0, 1], [0, 0]], dtype=torch.long))
+
+    dataset = MagicMock(spec=Dataset)
+    dataset.hdata = hdata
+    dataset.__len__.return_value = 1
+
+    loader = DataLoader(dataset, sample_full_hypergraph=True)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Unsupported task category for task='unsupported'."),
+    ):
+        loader.collate([sample])
+
+
 def test_collate_with_explicit_num_nodes_and_edges():
     # num_nodes and num_hyperedges are derived from unique IDs in hyperedge_index
     x = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=torch.float)

--- a/hypertorch/tests/types/hdata_test.py
+++ b/hypertorch/tests/types/hdata_test.py
@@ -1678,6 +1678,49 @@ def test_with_y_to_does_not_share_mutable_storage_with_source(hdata_with_all_mut
     __assert_mutating_result_keeps_source_tensors_unchanged(hdata, result)
 
 
+def test_with_y_replaces_labels_and_preserves_other_fields(mock_hdata):
+    y = torch.tensor([0.0, 0.5, 1.0], dtype=torch.float)
+
+    result = mock_hdata.with_y(y)
+
+    assert result is not mock_hdata
+    assert torch.equal(result.y, y)
+    assert torch.equal(result.x, mock_hdata.x)
+    assert torch.equal(result.hyperedge_index, mock_hdata.hyperedge_index)
+    assert result.hyperedge_attr is not None
+    assert mock_hdata.hyperedge_attr is not None
+    assert torch.equal(result.hyperedge_attr, mock_hdata.hyperedge_attr)
+    assert result.num_nodes == mock_hdata.num_nodes
+    assert result.num_hyperedges == mock_hdata.num_hyperedges
+    assert result.task == mock_hdata.task
+
+
+def test_with_y_none_uses_default_labels(mock_hdata):
+    mock_hdata.y = torch.zeros(mock_hdata.num_hyperedges, dtype=torch.float)
+
+    result = mock_hdata.with_y(None)
+
+    assert torch.equal(result.y, torch.ones(mock_hdata.num_hyperedges, dtype=torch.float))
+
+
+def test_with_y_clones_input_labels(mock_hdata):
+    original_y = torch.tensor([0.0, 0.5, 1.0], dtype=torch.float)
+    cloned_y = original_y.clone()
+
+    result = mock_hdata.with_y(original_y)
+    original_y[0] = 1.0
+
+    assert torch.equal(result.y, cloned_y)
+
+
+def test_with_y_does_not_share_mutable_storage_with_source(hdata_with_all_mutable_tensors):
+    hdata = hdata_with_all_mutable_tensors
+
+    result = hdata.with_y(torch.tensor([0.0, 0.5, 1.0], dtype=torch.float))
+
+    __assert_mutating_result_keeps_source_tensors_unchanged(hdata, result)
+
+
 def test_target_node_mask_defaults_to_all_nodes():
     x = torch.randn(4, 2, dtype=torch.float)
     hyperedge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long)
@@ -1717,6 +1760,34 @@ def test_with_target_node_mask_replaces_mask_and_preserves_other_fields():
     assert torch.equal(result.global_node_ids, hdata.global_node_ids)
     assert torch.equal(result.y, hdata.y)
     assert result.task == hdata.task
+
+
+def test_with_target_node_mask_none_uses_default_all_nodes():
+    hdata = HData(
+        x=torch.randn(3, 2, dtype=torch.float),
+        hyperedge_index=torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long),
+        target_node_mask=torch.tensor([True, False, False], dtype=torch.bool),
+        task="node-classification",
+    )
+
+    result = hdata.with_target_node_mask(None)
+
+    assert torch.equal(result.target_node_mask, torch.tensor([True, True, True], dtype=torch.bool))
+
+
+def test_with_target_node_mask_clones_input_mask():
+    hdata = HData(
+        x=torch.randn(3, 2, dtype=torch.float),
+        hyperedge_index=torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long),
+        task="node-classification",
+    )
+    original_target_node_mask = torch.tensor([False, True, True], dtype=torch.bool)
+    cloned_target_node_mask = original_target_node_mask.clone()
+
+    result = hdata.with_target_node_mask(original_target_node_mask)
+    original_target_node_mask[0] = True
+
+    assert torch.equal(result.target_node_mask, cloned_target_node_mask)
 
 
 def test_with_target_node_mask_does_not_share_mutable_storage_with_source():
@@ -1769,6 +1840,32 @@ def test_with_target_hyperedge_mask_replaces_mask_and_preserves_other_fields():
     assert torch.equal(result.global_node_ids, hdata.global_node_ids)
     assert torch.equal(result.y, hdata.y)
     assert result.task == hdata.task
+
+
+def test_with_target_hyperedge_mask_none_uses_default_all_hyperedges():
+    hdata = HData(
+        x=torch.randn(3, 2, dtype=torch.float),
+        hyperedge_index=torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long),
+        target_hyperedge_mask=torch.tensor([True, False], dtype=torch.bool),
+    )
+
+    result = hdata.with_target_hyperedge_mask(None)
+
+    assert torch.equal(result.target_hyperedge_mask, torch.tensor([True, True], dtype=torch.bool))
+
+
+def test_with_target_hyperedge_mask_clones_input_mask():
+    hdata = HData(
+        x=torch.randn(3, 2, dtype=torch.float),
+        hyperedge_index=torch.tensor([[0, 1, 2], [0, 0, 1]], dtype=torch.long),
+    )
+    original_target_hyperedge_mask = torch.tensor([False, True], dtype=torch.bool)
+    cloned_target_hyperedge_mask = original_target_hyperedge_mask.clone()
+
+    result = hdata.with_target_hyperedge_mask(original_target_hyperedge_mask)
+    original_target_hyperedge_mask[0] = True
+
+    assert torch.equal(result.target_hyperedge_mask, cloned_target_hyperedge_mask)
 
 
 def test_with_target_hyperedge_mask_does_not_share_mutable_storage_with_source():

--- a/hypertorch/types/hdata.py
+++ b/hypertorch/types/hdata.py
@@ -1086,7 +1086,7 @@ class HData:
         self.device = device if isinstance(device, torch.device) else torch.device(device)
         return self
 
-    def with_target_node_mask(self, target_node_mask: Tensor) -> HData:
+    def with_target_node_mask(self, target_node_mask: Tensor | None) -> HData:
         """
         Return a copy of this instance with a ``target_node_mask`` attribute set to the given mask.
 
@@ -1105,13 +1105,13 @@ class HData:
             num_nodes=self.num_nodes,
             num_hyperedges=self.num_hyperedges,
             global_node_ids=self.global_node_ids.clone(),
-            target_node_mask=target_node_mask.clone(),
+            target_node_mask=clone_optional_tensor(target_node_mask),
             target_hyperedge_mask=self.target_hyperedge_mask.clone(),
             y=self.y.clone(),
             task=self.task,
         )
 
-    def with_target_hyperedge_mask(self, target_hyperedge_mask: Tensor) -> HData:
+    def with_target_hyperedge_mask(self, target_hyperedge_mask: Tensor | None) -> HData:
         """
         Return a copy of this instance with ``target_hyperedge_mask`` set to the given mask.
 
@@ -1131,8 +1131,33 @@ class HData:
             num_hyperedges=self.num_hyperedges,
             global_node_ids=self.global_node_ids.clone(),
             target_node_mask=self.target_node_mask.clone(),
-            target_hyperedge_mask=target_hyperedge_mask.clone(),
+            target_hyperedge_mask=clone_optional_tensor(target_hyperedge_mask),
             y=self.y.clone(),
+            task=self.task,
+        )
+
+    def with_y(self, y: Tensor | None) -> HData:
+        """
+        Return a copy of this instance with a y attribute set to the given value.
+
+        Args:
+            y: The value to set for all entries in the y attribute.
+
+        Returns:
+            hdata: A new `HData` instance with the same attributes except for y,
+                which is set to a tensor of the given value.
+        """
+        return self.__class__(
+            x=self.x.clone(),
+            hyperedge_index=self.hyperedge_index.clone(),
+            hyperedge_weights=clone_optional_tensor(self.hyperedge_weights),
+            hyperedge_attr=clone_optional_tensor(self.hyperedge_attr),
+            num_nodes=self.num_nodes,
+            num_hyperedges=self.num_hyperedges,
+            global_node_ids=self.global_node_ids.clone(),
+            target_node_mask=self.target_node_mask.clone(),
+            target_hyperedge_mask=self.target_hyperedge_mask.clone(),
+            y=clone_optional_tensor(y),
             task=self.task,
         )
 


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Collate masks and labels when `sample_full_hypergraph=True`.
 
### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make format`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)