### PR TITLE
fix: add validation for hyperedge-only split parameters

### DIFF
--- a/hypertorch/data/dataset.py
+++ b/hypertorch/data/dataset.py
@@ -422,7 +422,8 @@ class Dataset(TorchDataset):
             ValueError: If ratios do not sum to ``1.0``, a final split has zero
                 hyperedges, if train coverage is requested for dense hyperlink-prediction
                 splits, or a requested sparse train-cover split cannot cover the full node
-                space.
+                space. If the task is node-related, raises a ValueError if
+                sparse hyperedge splitting or train coverage is requested.
         """
         if splitter is not None:
             return splitter.split(self)
@@ -431,6 +432,12 @@ class Dataset(TorchDataset):
             raise ValueError("'ratios' must be provided when no custom 'splitter' is provided.")
 
         if self.hdata.is_node_related_task:
+            self.__validate_hyperedge_split_only_parameter(
+                sparse_split_hyperedges=sparse_split_hyperedges,
+                cover_all_nodes_in_train_split=cover_all_nodes_in_train_split,
+                train_split_idx=train_split_idx,
+            )
+
             splits, _ = NodeDatasetSplitter(
                 node_space_setting=node_space_setting,
                 shuffle=shuffle,
@@ -523,9 +530,16 @@ class Dataset(TorchDataset):
         Raises:
             ValueError: If ratios do not sum to ``1.0``, a final split has zero
                 hyperedges, or a requested transductive train-cover split cannot
-                cover the full node space.
+                cover the full node space. If the task is node-related, raises a ValueError if
+                sparse hyperedge splitting or train coverage is requested.
         """
         if self.hdata.is_node_related_task:
+            self.__validate_hyperedge_split_only_parameter(
+                sparse_split_hyperedges=sparse_split_hyperedges,
+                cover_all_nodes_in_train_split=cover_all_nodes_in_train_split,
+                train_split_idx=train_split_idx,
+            )
+
             return NodeDatasetSplitter(
                 node_space_setting=node_space_setting,
                 shuffle=shuffle,
@@ -638,3 +652,29 @@ class Dataset(TorchDataset):
             stats: A dictionary containing various statistics about the hypergraph.
         """
         return self.hdata.stats()
+
+    def __validate_hyperedge_split_only_parameter(
+        self,
+        sparse_split_hyperedges: bool,
+        cover_all_nodes_in_train_split: bool,
+        train_split_idx: int,
+    ):
+        if sparse_split_hyperedges:
+            raise ValueError(
+                "Sparse hyperedge splitting is not applicable to node-related tasks. "
+                f"Got sparse_split_hyperedges={sparse_split_hyperedges} "
+                f"for task={self.hdata.task!r}."
+            )
+        if cover_all_nodes_in_train_split:
+            raise ValueError(
+                "Train coverage is not applicable to node-related tasks. "
+                "Do not set 'cover_all_nodes_in_train_split'. "
+                f"Got cover_all_nodes_in_train_split={cover_all_nodes_in_train_split} "
+                f"for task={self.hdata.task!r}."
+            )
+        if train_split_idx != 0:
+            raise ValueError(
+                "Train coverage is not applicable to node-related tasks. "
+                f"Got train_split_idx={train_split_idx} (should be omitted or 0) "
+                f"for task={self.hdata.task!r}."
+            )

--- a/hypertorch/tests/data/dataset_test.py
+++ b/hypertorch/tests/data/dataset_test.py
@@ -811,6 +811,83 @@ def test_split_inductive_with_ratios_node_classification_returns_final_node_rati
     assert torch.equal(splits[1].hdata.y, torch.tensor([11, 12, 13], dtype=torch.long))
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "expected_message"),
+    [
+        pytest.param(
+            {"sparse_split_hyperedges": True},
+            "Sparse hyperedge splitting is not applicable to node-related tasks. "
+            "Got sparse_split_hyperedges=True for task='node-classification'.",
+            id="sparse-hyperedge-split",
+        ),
+        pytest.param(
+            {"cover_all_nodes_in_train_split": True},
+            "Train coverage is not applicable to node-related tasks. "
+            "Do not set 'cover_all_nodes_in_train_split'. "
+            "Got cover_all_nodes_in_train_split=True for task='node-classification'.",
+            id="train-coverage",
+        ),
+        pytest.param(
+            {"train_split_idx": 1},
+            "Train coverage is not applicable to node-related tasks. "
+            "Got train_split_idx=1 (should be omitted or 0) for task='node-classification'.",
+            id="train-split-idx",
+        ),
+    ],
+)
+def test_node_classification_split_rejects_hyperedge_only_options(kwargs, expected_message):
+    hdata = HData(
+        x=torch.arange(4, dtype=torch.float).unsqueeze(1),
+        hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long),
+        y=torch.tensor([10, 11, 12, 13], dtype=torch.long),
+        task="node-classification",
+    )
+    dataset = Dataset.from_hdata(hdata, sampling_strategy="node")
+
+    with pytest.raises(ValueError, match=re.escape(expected_message)):
+        dataset.split(ratios=[0.5, 0.5], **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_message"),
+    [
+        pytest.param(
+            {"sparse_split_hyperedges": True},
+            "Sparse hyperedge splitting is not applicable to node-related tasks. "
+            "Got sparse_split_hyperedges=True for task='node-classification'.",
+            id="sparse-hyperedge-split",
+        ),
+        pytest.param(
+            {"cover_all_nodes_in_train_split": True},
+            "Train coverage is not applicable to node-related tasks. "
+            "Do not set 'cover_all_nodes_in_train_split'. "
+            "Got cover_all_nodes_in_train_split=True for task='node-classification'.",
+            id="train-coverage",
+        ),
+        pytest.param(
+            {"train_split_idx": 1},
+            "Train coverage is not applicable to node-related tasks. "
+            "Got train_split_idx=1 (should be omitted or 0) for task='node-classification'.",
+            id="train-split-idx",
+        ),
+    ],
+)
+def test_node_classification_split_with_ratios_rejects_hyperedge_only_options(
+    kwargs,
+    expected_message,
+):
+    hdata = HData(
+        x=torch.arange(4, dtype=torch.float).unsqueeze(1),
+        hyperedge_index=torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]], dtype=torch.long),
+        y=torch.tensor([10, 11, 12, 13], dtype=torch.long),
+        task="node-classification",
+    )
+    dataset = Dataset.from_hdata(hdata, sampling_strategy="node")
+
+    with pytest.raises(ValueError, match=re.escape(expected_message)):
+        dataset.split_with_ratios(ratios=[0.5, 0.5], **kwargs)
+
+
 def test_split_rejects_unsupported_task_category():
     hdata = HData(
         x=torch.arange(4, dtype=torch.float).unsqueeze(1),


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Add validation for hyperedge-only split parameters.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make format`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
