### PR TITLE
fix: print task always as a string

### DIFF
--- a/hypertorch/types/hdata.py
+++ b/hypertorch/types/hdata.py
@@ -207,15 +207,17 @@ class HData:
         hyperedge_attr_shape = (
             self.hyperedge_attr.shape if self.hyperedge_attr is not None else None
         )
+
+        task_as_str = str(self.task)
         target_node_mask_shape = (
             str(self.target_node_mask.shape)
             if self.is_node_related_task
-            else f"(ignored for task={self.task!r})"
+            else f"(ignored for task={task_as_str})"
         )
         target_hyperedge_mask_shape = (
             str(self.target_hyperedge_mask.shape)
             if self.is_hyperedge_related_task
-            else f"(ignored for task={self.task!r})"
+            else f"(ignored for task={task_as_str})"
         )
 
         return (
@@ -230,7 +232,7 @@ class HData:
             f"    hyperedge_weights_shape={hyperedge_weights_shape},\n"
             f"    hyperedge_attr_shape={hyperedge_attr_shape},\n"
             f"    y_shape={self.y.shape},\n"
-            f"    task={self.task!r},\n"
+            f"    task={task_as_str!r},\n"
             f"    device={self.device}\n"
             f")"
         )


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Now task prints always as a string.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make format`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
