### PR TITLE
fix: correct exp name usage in loggers/trainer and force no duplicate exp dir

### DIFF
--- a/docs/user-guide/loggers.md
+++ b/docs/user-guide/loggers.md
@@ -35,6 +35,77 @@ with MultiModelTrainer(model_configs=configs, logger=logger, max_epochs=10) as t
     trainer.fit_all(train_dataloader=train_loader, val_dataloader=val_loader)
 ```
 
+## Distributed metric logging
+
+When training in a distributed setting, each process computes metrics separately.
+HyperTorch's comparison loggers write files only from global
+rank zero to prevent multiple processes from writing the same file.
+
+Metrics must be synchronized before they reach the logger. For built-in hypertorch
+models, pass `sync_dist=True` through `metrics_log_kwargs`:
+
+```python
+from hypertorch.node_classification import GCNClassifier
+from hypertorch.train import MultiModelTrainer
+from hypertorch.types import ModelConfig
+
+model = GCNClassifier(
+    classifier_config={
+        "in_channels": 32,
+        "out_channels": 2,
+    },
+    metrics_log_kwargs={"sync_dist": True},
+)
+
+configs = [
+    ModelConfig(
+        name="gcn",
+        version="default",
+        model=model,
+    )
+]
+
+with MultiModelTrainer(
+    model_configs=configs,
+    accelerator="gpu",
+    devices=2,
+    strategy="ddp",
+    max_epochs=50,
+) as trainer:
+    trainer.fit_all(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+    )
+    trainer.test_all(dataloader=test_loader)
+```
+
+`metrics_log_kwargs` is a model option. Do not place it in
+`ModelConfig.trainer_kwargs`: `sync_dist` configures `LightningModule.log()`, not
+the Lightning `Trainer`.
+
+For a custom Lightning module, enable synchronization directly when logging plain
+tensor values:
+
+```python
+def training_step(self, batch, batch_idx):
+    loss = self.compute_loss(batch)
+    batch_size = ...  # Number of samples used to compute the loss.
+
+    self.log(
+        "train/loss",
+        loss,
+        batch_size=batch_size,
+        sync_dist=True,
+        on_step=False,
+        on_epoch=True,
+    )
+    return loss
+```
+
+TorchMetrics objects synchronize their distributed states when computed. Plain tensor
+values, including training, validation, and test losses, require `sync_dist=True` to
+represent data from every rank.
+
 ## Next steps
 
 - Enable/inspect TensorBoard: [TensorBoard](tensorboard.md).

--- a/docs/user-guide/training.md
+++ b/docs/user-guide/training.md
@@ -136,6 +136,80 @@ train_ds, test_ds = dataset.split(
 
 Use `split_with_ratios(...)` instead of `split(...)` when you need the final target-hyperedge ratios after optional sparse rebalancing.
 
+## Distributed experiment directories
+
+When `experiment_name` is omitted, `MultiModelTrainer` reserves the next available
+directory under `default_root_dir`, such as `experiment_0`. On a single machine,
+Lightning's default DDP launcher starts child processes after the parent constructs
+the trainer. HyperTorch exports the selected directory through an indexed environment
+variable, allowing every child rank to reuse the parent's directory:
+
+```text
+HYPERTORCH_AUTO_EXPERIMENT_DIR_0=/absolute/path/to/experiment_0
+```
+
+The index identifies an auto-named `MultiModelTrainer` by construction order. When a
+script constructs two trainers, the parent exports two values:
+
+```text
+HYPERTORCH_AUTO_EXPERIMENT_DIR_0=/absolute/path/to/experiment_0
+HYPERTORCH_AUTO_EXPERIMENT_DIR_1=/absolute/path/to/experiment_1
+```
+
+Relaunched processes must construct auto-named trainers in the same order as the
+parent. Each trainer and all of its ranks then share one experiment directory.
+
+### External launchers
+
+External launchers such as `torchrun` start all ranks as sibling processes before the
+training script runs. An environment variable created later by rank zero cannot
+propagate to the other ranks. For these launchers, provide the same explicit
+`experiment_name` to every rank:
+
+```python
+import os
+
+from hypertorch.train import MultiModelTrainer
+
+run_id = os.environ["HYPERTORCH_RUN_ID"]
+
+with MultiModelTrainer(
+    model_configs=configs,
+    default_root_dir="hypertorch_logs",
+    experiment_name=f"experiment_{run_id}",
+    accelerator="gpu",
+    devices=4,
+    strategy="ddp",
+) as trainer:
+    trainer.fit_all(
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+    )
+```
+
+Set the run identifier before starting `torchrun` so every rank inherits it:
+
+```bash
+HYPERTORCH_RUN_ID=my-run-001 \
+torchrun --nproc-per-node=4 train.py
+```
+
+Alternatively, create the directory and configure the indexed value before launch:
+
+```bash
+mkdir -p /absolute/path/to/hypertorch_logs/experiment_0
+export HYPERTORCH_AUTO_EXPERIMENT_DIR_0=/absolute/path/to/hypertorch_logs/experiment_0
+torchrun --nproc-per-node=4 train.py
+```
+
+For multi-machine jobs, the resolved directory must be accessible at the same path
+from every machine, normally through shared storage. A node-local path produces a
+separate set of files on each machine even when its textual path is identical.
+
+Experiment-directory sharing only coordinates artifact locations. Distributed metric
+values must also be synchronized before global rank zero writes them. See
+[Distributed metric logging](loggers.md#distributed-metric-logging).
+
 ## Per-model trainer options
 
 `MultiModelTrainer` values are shared defaults. Set per-model trainer options on an

--- a/hypertorch/integration_tests/train/trainer_integration_test.py
+++ b/hypertorch/integration_tests/train/trainer_integration_test.py
@@ -1,11 +1,18 @@
+import os
+import subprocess
+import sys
+
 import pytest
 import lightning as L
 import torch
 
+from itertools import count
 from pathlib import Path
+from textwrap import dedent
 from torch import Tensor, nn, optim
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import CSVLogger
+import hypertorch.train.trainer as trainer_module
 from hypertorch.train import MultiModelTrainer
 from hypertorch.types import HData, ModelConfig
 from hypertorch.data import DataLoader, Dataset
@@ -210,6 +217,171 @@ def test_auto_named_trainers_reserve_distinct_experiment_directories(
         assert "second:0" not in first_comparison
         assert "second:0" in second_comparison
         assert "first:0" not in second_comparison
+
+
+@pytest.mark.integration
+def test_auto_named_trainer_reuses_parent_experiment_dir_in_relaunched_processes(
+    tmp_path,
+    monkeypatch,
+):
+    environment_variable = "HYPERTORCH_AUTO_EXPERIMENT_DIR_0"
+    monkeypatch.delenv(environment_variable, raising=False)
+    monkeypatch.setattr(trainer_module, "AUTO_EXPERIMENT_INDEX", count())
+
+    parent_trainer = MultiModelTrainer(
+        model_configs=[
+            ModelConfig(
+                name="parent",
+                version="0",
+                model=TinyBinaryClassifier(),
+            )
+        ],
+        default_root_dir=tmp_path,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+    expected_log_dir = (tmp_path / "experiment_0").resolve()
+
+    child_script = dedent(
+        """
+        import lightning as L
+        import os
+        from hypertorch.train import MultiModelTrainer
+        from hypertorch.types import ModelConfig
+
+        trainer = MultiModelTrainer(
+            model_configs=[
+                ModelConfig(
+                    name="child",
+                    version=os.environ["SIMULATED_CHILD_RANK"],
+                    model=L.LightningModule(),
+                )
+            ],
+            default_root_dir=os.environ["SIMULATED_LOG_ROOT"],
+            logger=False,
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+        )
+        print(f"SIMULATED_CHILD_LOG_DIR={trainer.log_dir}")
+        """
+    )
+
+    child_log_dirs = []
+    for child_rank in ("1", "2"):
+        child_environment = os.environ.copy()
+        child_environment["SIMULATED_CHILD_RANK"] = child_rank
+        child_environment["SIMULATED_LOG_ROOT"] = str(tmp_path)
+        child_process = subprocess.run(
+            [sys.executable, "-c", child_script],
+            check=True,
+            capture_output=True,
+            env=child_environment,
+            text=True,
+        )
+        child_log_dir_line = next(
+            line
+            for line in child_process.stdout.splitlines()
+            if line.startswith("SIMULATED_CHILD_LOG_DIR=")
+        )
+        child_log_dirs.append(Path(child_log_dir_line.split("=", maxsplit=1)[1]))
+
+    assert parent_trainer.log_dir == expected_log_dir
+    assert child_log_dirs == [expected_log_dir, expected_log_dir]
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["experiment_0"]
+
+
+@pytest.mark.integration
+def test_two_auto_named_trainers_will_reuse_parent_experiment_dirs_in_relaunched_processes(
+    tmp_path,
+    monkeypatch,
+):
+    for trainer_index in range(2):
+        monkeypatch.delenv(
+            f"HYPERTORCH_AUTO_EXPERIMENT_DIR_{trainer_index}",
+            raising=False,
+        )
+    monkeypatch.setattr(trainer_module, "AUTO_EXPERIMENT_INDEX", count())
+
+    parent_trainers = [
+        MultiModelTrainer(
+            model_configs=[
+                ModelConfig(
+                    name=f"parent_{trainer_index}",
+                    version="0",
+                    model=TinyBinaryClassifier(),
+                )
+            ],
+            default_root_dir=tmp_path,
+            logger=False,
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+        )
+        for trainer_index in range(2)
+    ]
+    expected_log_dirs = [
+        (tmp_path / f"experiment_{trainer_index}").resolve() for trainer_index in range(2)
+    ]
+
+    child_script = dedent(
+        """
+        import lightning as L
+        import os
+
+        from hypertorch.train import MultiModelTrainer
+        from hypertorch.types import ModelConfig
+
+
+        for trainer_index in range(2):
+            trainer = MultiModelTrainer(
+                model_configs=[
+                    ModelConfig(
+                        name=f"child_{trainer_index}",
+                        version=os.environ["SIMULATED_CHILD_RANK"],
+                        model=L.LightningModule(),
+                    )
+                ],
+                default_root_dir=os.environ["SIMULATED_LOG_ROOT"],
+                logger=False,
+                enable_checkpointing=False,
+                enable_progress_bar=False,
+                enable_model_summary=False,
+            )
+            print(
+                f"SIMULATED_CHILD_LOG_DIR_{trainer_index}={trainer.log_dir}"
+            )
+        """
+    )
+
+    child_log_dirs_by_rank = []
+    for child_rank in ("1", "2"):
+        child_environment = os.environ.copy()
+        child_environment["SIMULATED_CHILD_RANK"] = child_rank
+        child_environment["SIMULATED_LOG_ROOT"] = str(tmp_path)
+        child_process = subprocess.run(
+            [sys.executable, "-c", child_script],
+            check=True,
+            capture_output=True,
+            env=child_environment,
+            text=True,
+        )
+        child_log_dirs = [
+            Path(line.split("=", maxsplit=1)[1])
+            for line in child_process.stdout.splitlines()
+            if line.startswith("SIMULATED_CHILD_LOG_DIR_")
+        ]
+        child_log_dirs_by_rank.append(child_log_dirs)
+
+    assert [trainer.log_dir for trainer in parent_trainers] == expected_log_dirs
+    assert child_log_dirs_by_rank == [expected_log_dirs, expected_log_dirs]
+
+    assert sorted(path.name for path in tmp_path.iterdir()) == [
+        "experiment_0",
+        "experiment_1",
+    ]
 
 
 @pytest.mark.integration

--- a/hypertorch/integration_tests/train/trainer_integration_test.py
+++ b/hypertorch/integration_tests/train/trainer_integration_test.py
@@ -140,6 +140,79 @@ def test_fit_and_test_all_trains_and_evaluates_models(
 
 
 @pytest.mark.integration
+def test_auto_named_trainers_reserve_distinct_experiment_directories(
+    tmp_path,
+    mock_tiny_dataloader,
+):
+    first_model_configs = [
+        ModelConfig(
+            name="first",
+            version="0",
+            model=TinyBinaryClassifier(),
+        )
+    ]
+    second_model_configs = [
+        ModelConfig(
+            name="second",
+            version="0",
+            model=TinyBinaryClassifier(),
+        )
+    ]
+
+    with (
+        MultiModelTrainer(
+            model_configs=first_model_configs,
+            default_root_dir=tmp_path,
+            max_epochs=1,
+            accelerator="auto",
+            devices=1,
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            log_every_n_steps=1,
+        ) as first_trainer,
+        MultiModelTrainer(
+            model_configs=second_model_configs,
+            default_root_dir=tmp_path,
+            max_epochs=1,
+            accelerator="auto",
+            devices=1,
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            log_every_n_steps=1,
+        ) as second_trainer,
+    ):
+        assert first_trainer.log_dir == tmp_path / "experiment_0"
+        assert second_trainer.log_dir == tmp_path / "experiment_1"
+        assert first_trainer.log_dir.is_dir()
+        assert second_trainer.log_dir.is_dir()
+
+        for trainer in (first_trainer, second_trainer):
+            trainer.fit_all(
+                train_dataloader=mock_tiny_dataloader,
+                val_dataloader=mock_tiny_dataloader,
+                verbose=False,
+            )
+            trainer.test_all(
+                dataloader=mock_tiny_dataloader,
+                verbose=False,
+                verbose_loop=False,
+            )
+
+        __assert_default_logger_outputs(first_trainer.log_dir, first_model_configs)
+        __assert_default_logger_outputs(second_trainer.log_dir, second_model_configs)
+
+        first_comparison = (first_trainer.log_dir / "comparison" / "overall.md").read_text()
+        second_comparison = (second_trainer.log_dir / "comparison" / "overall.md").read_text()
+
+        assert "first:0" in first_comparison
+        assert "second:0" not in first_comparison
+        assert "second:0" in second_comparison
+        assert "first:0" not in second_comparison
+
+
+@pytest.mark.integration
 def test_custom_logger_is_used_instead_of_default_loggers(
     tmp_path,
     mock_tiny_dataloader,

--- a/hypertorch/tests/train/latex_logger_test.py
+++ b/hypertorch/tests/train/latex_logger_test.py
@@ -219,6 +219,7 @@ def test_clear_removes_metrics_only_for_requested_experiment(tmp_path, mock_opti
     assert second_logger.store == {"model_b": {"test/auc": 0.90}}
 
     second_logger.clear("exp_clear_second")
+    assert second_logger.store == {}
 
 
 def test_destroy_removes_metrics_for_all_experiments(tmp_path, mock_option_configs):

--- a/hypertorch/tests/train/latex_logger_test.py
+++ b/hypertorch/tests/train/latex_logger_test.py
@@ -174,18 +174,50 @@ def test_finalize_no_relevant_metrics_writes_no_file(tmp_path, mock_option_confi
     assert not (tmp_path / "comparison" / "test.tex").exists()
 
 
-def test_clear_removes_metrics_for_experiment(tmp_path, mock_option_configs):
-    logger = LaTexTableLogger(
+def test_clear_removes_metrics_only_for_requested_experiment(tmp_path, mock_option_configs):
+    first_logger = LaTexTableLogger(
         save_dir=str(tmp_path),
         model_name="model_a",
-        experiment_name="exp_clear",
+        experiment_name="exp_clear_first",
+        options=mock_option_configs,
+    )
+    second_logger = LaTexTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_b",
+        experiment_name="exp_clear_second",
         options=mock_option_configs,
     )
 
-    logger.log_metrics({"test/auc": 0.80, "train/loss": 0.50})
-    logger.clear("exp_clear")
+    first_logger.log_metrics({"test/auc": 0.80, "train/loss": 0.50})
+    second_logger.log_metrics({"test/auc": 0.90})
+    first_logger.clear("exp_clear_first")
 
-    assert logger.store == {}
+    assert first_logger.store == {}
+    assert second_logger.store == {"model_b": {"test/auc": 0.90}}
+
+    second_logger.clear("exp_clear_second")
+
+
+def test_destroy_removes_metrics_for_all_experiments(tmp_path, mock_option_configs):
+    first_logger = LaTexTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_a",
+        experiment_name="exp_destroy_first",
+        options=mock_option_configs,
+    )
+    second_logger = LaTexTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_b",
+        experiment_name="exp_destroy_second",
+        options=mock_option_configs,
+    )
+
+    first_logger.log_metrics({"test/auc": 0.80})
+    second_logger.log_metrics({"test/auc": 0.90})
+    first_logger.destroy()
+
+    assert first_logger.store == {}
+    assert second_logger.store == {}
 
 
 def test_finalize_writes_section_spacing_and_midrule_lines(tmp_path, mock_option_configs):

--- a/hypertorch/tests/train/latex_logger_test.py
+++ b/hypertorch/tests/train/latex_logger_test.py
@@ -2,6 +2,7 @@ import pytest
 import re
 
 from textwrap import dedent
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 from hypertorch.train import (
     LaTexTableConfig,
     LaTexTableLogger,
@@ -73,6 +74,28 @@ def test_latex_logger_log_metrics_accumulates_metrics(tmp_path, mock_option_conf
     logger.finalize("success")
     store = logger.store
     assert store == {"model_a": {"test/auc": 0.80, "train/loss": 0.50, "val/loss": 0.40}}
+
+
+def test_latex_logger_does_not_log_or_save_on_nonzero_rank(
+    tmp_path,
+    mock_option_configs,
+    monkeypatch,
+):
+    experiment_name = "exp_nonzero_rank"
+    logger = LaTexTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_a",
+        experiment_name=experiment_name,
+        options=mock_option_configs,
+    )
+    logger.clear(experiment_name)
+    monkeypatch.setattr(rank_zero_only, "rank", 1)
+
+    logger.log_metrics({"test/auc": 0.80})
+    logger.finalize("success")
+
+    assert logger.store == {}
+    assert not (tmp_path / "comparison").exists()
 
 
 def test_markdown_table_logger_finalize_does_not_save_when_no_results(

--- a/hypertorch/tests/train/markdown_logger_test.py
+++ b/hypertorch/tests/train/markdown_logger_test.py
@@ -59,6 +59,48 @@ def test_markdown_table_logger_log_metrics_accumulates_metrics(tmp_path):
     assert store == {"model_a": {"test/auc": 0.80, "train/loss": 0.50, "val/loss": 0.40}}
 
 
+def test_clear_removes_metrics_only_for_requested_experiment(tmp_path):
+    first_logger = MarkdownTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_a",
+        experiment_name="exp_clear_first",
+    )
+    second_logger = MarkdownTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_b",
+        experiment_name="exp_clear_second",
+    )
+
+    first_logger.log_metrics({"test/auc": 0.80, "train/loss": 0.50})
+    second_logger.log_metrics({"test/auc": 0.90})
+    first_logger.clear("exp_clear_first")
+
+    assert first_logger.store == {}
+    assert second_logger.store == {"model_b": {"test/auc": 0.90}}
+
+    second_logger.clear("exp_clear_second")
+
+
+def test_destroy_removes_metrics_for_all_experiments(tmp_path):
+    first_logger = MarkdownTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_a",
+        experiment_name="exp_destroy_first",
+    )
+    second_logger = MarkdownTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_b",
+        experiment_name="exp_destroy_second",
+    )
+
+    first_logger.log_metrics({"test/auc": 0.80})
+    second_logger.log_metrics({"test/auc": 0.90})
+    first_logger.destroy()
+
+    assert first_logger.store == {}
+    assert second_logger.store == {}
+
+
 def test_markdown_table_logger_finalize_does_not_save_when_no_results(tmp_path):
     experiment_name = "exp3"
 

--- a/hypertorch/tests/train/markdown_logger_test.py
+++ b/hypertorch/tests/train/markdown_logger_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from textwrap import dedent
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 from hypertorch.train import MarkdownTableLogger
 
 
@@ -57,6 +58,23 @@ def test_markdown_table_logger_log_metrics_accumulates_metrics(tmp_path):
     logger.finalize("success")
     store = logger.store
     assert store == {"model_a": {"test/auc": 0.80, "train/loss": 0.50, "val/loss": 0.40}}
+
+
+def test_markdown_table_logger_does_not_log_or_save_on_nonzero_rank(tmp_path, monkeypatch):
+    experiment_name = "exp_nonzero_rank"
+    logger = MarkdownTableLogger(
+        save_dir=str(tmp_path),
+        model_name="model_a",
+        experiment_name=experiment_name,
+    )
+    logger.clear(experiment_name)
+    monkeypatch.setattr(rank_zero_only, "rank", 1)
+
+    logger.log_metrics({"test/auc": 0.80})
+    logger.finalize("success")
+
+    assert logger.store == {}
+    assert not (tmp_path / "comparison").exists()
 
 
 def test_clear_removes_metrics_only_for_requested_experiment(tmp_path):

--- a/hypertorch/tests/train/markdown_logger_test.py
+++ b/hypertorch/tests/train/markdown_logger_test.py
@@ -97,6 +97,7 @@ def test_clear_removes_metrics_only_for_requested_experiment(tmp_path):
     assert second_logger.store == {"model_b": {"test/auc": 0.90}}
 
     second_logger.clear("exp_clear_second")
+    assert second_logger.store == {}
 
 
 def test_destroy_removes_metrics_for_all_experiments(tmp_path):

--- a/hypertorch/tests/train/trainer_test.py
+++ b/hypertorch/tests/train/trainer_test.py
@@ -1,6 +1,8 @@
+import os
 import pytest
 import re
 
+from pathlib import Path
 from types import MappingProxyType
 from unittest.mock import MagicMock, patch
 from lightning.pytorch.callbacks import Callback
@@ -875,6 +877,62 @@ def test_init_auto_increments_experiment_name(
 
     for call in mock_latex_logger_cls.call_args_list:
         assert "experiment_2" in str(call.kwargs["save_dir"])
+
+
+@patch("hypertorch.train.trainer.AUTO_EXPERIMENT_INDEX", iter([7]))
+@patch("hypertorch.train.trainer.L.Trainer")
+@patch("hypertorch.train.trainer.CSVLogger")
+@patch("hypertorch.train.trainer.MarkdownTableLogger")
+@patch("hypertorch.train.trainer.LaTexTableLogger")
+def test_init_exports_auto_experiment_dir_for_distributed_children(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+    monkeypatch,
+):
+    environment_variable = "HYPERTORCH_AUTO_EXPERIMENT_DIR_7"
+    monkeypatch.delenv(environment_variable, raising=False)
+
+    trainer = MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=tmp_path,
+    )
+
+    assert trainer.log_dir == (tmp_path / "experiment_0").resolve()
+    assert trainer.log_dir == Path(os.environ[environment_variable])
+
+
+@patch("hypertorch.train.trainer.AUTO_EXPERIMENT_INDEX", iter([8]))
+@patch("hypertorch.train.trainer.L.Trainer")
+@patch("hypertorch.train.trainer.CSVLogger")
+@patch("hypertorch.train.trainer.MarkdownTableLogger")
+@patch("hypertorch.train.trainer.LaTexTableLogger")
+def test_init_reuses_auto_experiment_dir_inherited_by_distributed_child(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+    monkeypatch,
+):
+    inherited_log_dir = tmp_path / "experiment_parent"
+    inherited_log_dir.mkdir()
+    monkeypatch.setenv(
+        "HYPERTORCH_AUTO_EXPERIMENT_DIR_8",
+        str(inherited_log_dir),
+    )
+
+    trainer = MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=tmp_path,
+    )
+
+    assert trainer.log_dir == inherited_log_dir
+    assert not (tmp_path / "experiment_0").exists()
 
 
 @patch("hypertorch.train.trainer.L.Trainer")

--- a/hypertorch/tests/train/trainer_test.py
+++ b/hypertorch/tests/train/trainer_test.py
@@ -879,6 +879,54 @@ def test_init_auto_increments_experiment_name(
         assert "experiment_2" in str(call.kwargs["save_dir"])
 
 
+@patch("hypertorch.train.trainer.L.Trainer")
+def test_init_retries_when_another_trainer_reserves_the_same_experiment_dir(
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+    monkeypatch,
+):
+    original_mkdir = Path.mkdir
+    reservation_attempts = []
+    collision_simulated = False
+
+    def mkdir_with_collision(path, *args, **kwargs):
+        nonlocal collision_simulated  # Use nonlocal to modify the outer variable
+
+        is_called_by_trainer = (
+            path.parent == tmp_path
+            and path.name.startswith("experiment_")
+            and kwargs.get("exist_ok") is False
+        )
+
+        # We simulate a race condition where another trainer reserves the experiment_0 directory
+        # before this trainer can create it. The next call, will select experiment_1,
+        # which will succeed and the trainer will then create the experiment_1 directory.
+        if is_called_by_trainer:
+            reservation_attempts.append(path.name)
+
+            if not collision_simulated:
+                # Simulate another trainer creating this directory first,
+                # then trainer reaches its atomic mkdir(exist_ok=False) call.
+                original_mkdir(path)
+                collision_simulated = True
+
+        return original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_collision)
+
+    trainer = MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=tmp_path,
+        logger=False,
+        enable_checkpointing=False,
+    )
+
+    assert collision_simulated
+    assert reservation_attempts == ["experiment_0", "experiment_1"]
+    assert trainer.log_dir == (tmp_path / "experiment_1").resolve()
+
+
 @patch("hypertorch.train.trainer.AUTO_EXPERIMENT_INDEX", iter([7]))
 @patch("hypertorch.train.trainer.L.Trainer")
 @patch("hypertorch.train.trainer.CSVLogger")

--- a/hypertorch/tests/train/trainer_test.py
+++ b/hypertorch/tests/train/trainer_test.py
@@ -5,7 +5,7 @@ from types import MappingProxyType
 from unittest.mock import MagicMock, patch
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.callbacks import ModelCheckpoint
-from hypertorch.train import MultiModelTrainer
+from hypertorch.train import ExperimentSharedLogger, MultiModelTrainer
 from hypertorch.types import ModelConfig
 from hypertorch.tests import new_mock_trainer
 
@@ -1751,6 +1751,47 @@ def test_finalize_terminates_tensorboard_process(
 @patch("hypertorch.train.trainer.CSVLogger")
 @patch("hypertorch.train.trainer.MarkdownTableLogger")
 @patch("hypertorch.train.trainer.LaTexTableLogger")
+def test_finalize_clears_shared_train_and_test_loggers(
+    mock_latex_logger_cls,
+    mock_md_logger_cls,
+    mock_csv_logger_cls,
+    mock_trainer_cls,
+    mock_model_configs,
+    tmp_path,
+):
+    experiment_name = "experiment_to_clear"
+    trainer = MultiModelTrainer(
+        mock_model_configs,
+        default_root_dir=str(tmp_path),
+        experiment_name=experiment_name,
+    )
+    shared_loggers = []
+    non_shared_loggers = []
+    for model_config in mock_model_configs:
+        train_logger = MagicMock(spec=ExperimentSharedLogger)
+        test_logger = MagicMock(spec=ExperimentSharedLogger)
+        train_non_shared_logger = MagicMock()
+        test_non_shared_logger = MagicMock()
+        model_config.trainer = new_mock_trainer()
+        model_config.trainer.loggers = [train_logger, train_non_shared_logger]
+        model_config.test_trainer = new_mock_trainer()
+        model_config.test_trainer.loggers = [test_logger, test_non_shared_logger]
+        shared_loggers.extend((train_logger, test_logger))
+        non_shared_loggers.extend((train_non_shared_logger, test_non_shared_logger))
+
+    trainer.finalize()
+
+    experiment_key = str(tmp_path / experiment_name)
+    for logger in shared_loggers:
+        logger.clear.assert_called_once_with(experiment_key)
+    for logger in non_shared_loggers:
+        logger.clear.assert_not_called()
+
+
+@patch("hypertorch.train.trainer.L.Trainer")
+@patch("hypertorch.train.trainer.CSVLogger")
+@patch("hypertorch.train.trainer.MarkdownTableLogger")
+@patch("hypertorch.train.trainer.LaTexTableLogger")
 def test_wait_does_nothing_when_no_tensorboard_process(
     mock_latex_logger_cls,
     mock_md_logger_cls,
@@ -1941,4 +1982,4 @@ def test_init_always_create_default_markdown_logger_per_model(
 
     for call in mock_markdown_logger_cls.call_args_list:
         assert call.kwargs["model_name"] in full_model_names
-        assert call.kwargs["experiment_name"] == "experiment_0"
+        assert call.kwargs["experiment_name"].endswith("experiment_0")

--- a/hypertorch/train/__init__.py
+++ b/hypertorch/train/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from .logger import ExperimentSharedLogger
+
 from .latex_logger import LaTexTableConfig, LaTexTableLogger, colorize_metric_value
 
 from .markdown_logger import MarkdownTableLogger
@@ -9,6 +11,7 @@ from .trainer import MultiModelTrainer
 logging.getLogger("lightning.pytorch").setLevel(logging.ERROR)
 
 __all__ = [
+    "ExperimentSharedLogger",
     "LaTexTableConfig",
     "LaTexTableLogger",
     "MarkdownTableLogger",

--- a/hypertorch/train/latex_logger.py
+++ b/hypertorch/train/latex_logger.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, ClassVar, TypedDict
 from collections.abc import Mapping
 from typing_extensions import NotRequired
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 from hypertorch.utils import LATEX_CHARACTER_ESCAPE_TABLE, escape, validate_is_non_negative
 
 from hypertorch.train.logger import ExperimentSharedLogger
@@ -116,6 +117,10 @@ class LaTexTableLogger(ExperimentSharedLogger):
     state of all accumulated metrics is written to a LaTex file. The last model to
     finalize produces the most complete table.
 
+    In distributed runs, only global rank zero accumulates metrics and writes tables.
+    Metrics must therefore be synchronized before they reach the logger, for example by
+    passing ``sync_dist=True`` to Lightning's metric logging methods.
+
     This means the file is progressively updated as models finish training/testing,
     so you can open it mid-run to see partial results.
     """
@@ -215,10 +220,10 @@ class LaTexTableLogger(ExperimentSharedLogger):
         Destroy the internal shared state of the logger.
 
         Caution: This method should be used with care, as it will clear all shared
-            state across experiments and processes. This means that any metrics or data logged
-            by other experiments will be lost as well. Use this method only when you are certain
-            that you want to clear all shared state, and not just the state for
-            a specific experiment. In that case, use the `clear` methods instead.
+            state across experiments in the current process. This means that any metrics
+            or data logged by other experiments will be lost as well. Use this method only
+            when you are certain that you want to clear all shared state, and not just the
+            state for a specific experiment. In that case, use the `clear` methods instead.
         """
         self.__shared_stores.clear()
 
@@ -231,6 +236,7 @@ class LaTexTableLogger(ExperimentSharedLogger):
         """
         pass
 
+    @rank_zero_only
     def log_metrics(self, metrics: dict[str, Any], step: int | None = None) -> None:
         """Accumulate metrics for this model. Called by Lightning on every log step.
 
@@ -242,6 +248,7 @@ class LaTexTableLogger(ExperimentSharedLogger):
             store[self.__model_name] = {}
         store[self.__model_name].update(metrics)
 
+    @rank_zero_only
     def finalize(self, status: str) -> None:
         """Write the LaTex comparison table with all accumulated metrics so far.
 

--- a/hypertorch/train/latex_logger.py
+++ b/hypertorch/train/latex_logger.py
@@ -3,7 +3,8 @@ from typing import Any, ClassVar, TypedDict
 from collections.abc import Mapping
 from typing_extensions import NotRequired
 from hypertorch.utils import LATEX_CHARACTER_ESCAPE_TABLE, escape, validate_is_non_negative
-from lightning.pytorch.loggers import Logger
+
+from hypertorch.train.logger import ExperimentSharedLogger
 
 
 def collect_metric_bounds(
@@ -106,7 +107,7 @@ class LaTexTableConfig(TypedDict):
     border: NotRequired[bool]
 
 
-class LaTexTableLogger(Logger):
+class LaTexTableLogger(ExperimentSharedLogger):
     """
     A Lightning Logger that accumulates metrics and writes a LaTex comparison table.
 
@@ -208,6 +209,18 @@ class LaTexTableLogger(Logger):
             experiment_name: The experiment name whose data should be cleared.
         """
         self.__shared_stores.pop(experiment_name, None)
+
+    def destroy(self) -> None:
+        """
+        Destroy the internal shared state of the logger.
+
+        Caution: This method should be used with care, as it will clear all shared
+            state across experiments and processes. This means that any metrics or data logged
+            by other experiments will be lost as well. Use this method only when you are certain
+            that you want to clear all shared state, and not just the state for
+            a specific experiment. In that case, use the `clear` methods instead.
+        """
+        self.__shared_stores.clear()
 
     def log_hyperparams(self, params: Any) -> None:
         """

--- a/hypertorch/train/logger.py
+++ b/hypertorch/train/logger.py
@@ -5,7 +5,7 @@ from lightning.pytorch.loggers import Logger
 class ExperimentSharedLogger(Logger, ABC):
     """
     Extends `lightning.pytorch.loggers.Logger` to provide a base class
-    for experiment loggers that are shared across multiple processes.
+    for experiment loggers that share state across instances in one process.
     """
 
     @abstractmethod
@@ -24,9 +24,9 @@ class ExperimentSharedLogger(Logger, ABC):
         Destroy the internal shared state of the logger.
 
         Caution: This method should be used with care, as it will clear all shared
-            state across experiments and processes. This means that any metrics or data logged
-            by other experiments will be lost as well. Use this method only when you are certain
-            that you want to clear all shared state, and not just the state for
-            a specific experiment. In that case, use the `clear` methods instead.
+            state across experiments in the current process. This means that any metrics
+            or data logged by other experiments will be lost as well. Use this method only
+            when you are certain that you want to clear all shared state, and not just the
+            state for a specific experiment. In that case, use the `clear` methods instead.
         """
         raise NotImplementedError("Subclasses must implement the destroy method.")

--- a/hypertorch/train/logger.py
+++ b/hypertorch/train/logger.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from lightning.pytorch.loggers import Logger
+
+
+class ExperimentSharedLogger(Logger, ABC):
+    """
+    Extends `lightning.pytorch.loggers.Logger` to provide a base class
+    for experiment loggers that are shared across multiple processes.
+    """
+
+    @abstractmethod
+    def clear(self, experiment_name: str) -> None:
+        """
+        Clear the internal state of the logger for a specific experiment.
+
+        Args:
+            experiment_name: The name of the experiment to clear.
+        """
+        raise NotImplementedError("Subclasses must implement the clear method.")
+
+    @abstractmethod
+    def destroy(self) -> None:
+        """
+        Destroy the internal shared state of the logger.
+
+        Caution: This method should be used with care, as it will clear all shared
+            state across experiments and processes. This means that any metrics or data logged
+            by other experiments will be lost as well. Use this method only when you are certain
+            that you want to clear all shared state, and not just the state for
+            a specific experiment. In that case, use the `clear` methods instead.
+        """
+        raise NotImplementedError("Subclasses must implement the destroy method.")

--- a/hypertorch/train/markdown_logger.py
+++ b/hypertorch/train/markdown_logger.py
@@ -2,12 +2,13 @@ import copy
 
 from pathlib import Path
 from typing import Any, ClassVar
-from lightning.pytorch.loggers import Logger
 from collections.abc import Mapping
 from hypertorch.utils import MARKDOWN_CHARACTER_ESCAPE_TABLE, escape, validate_is_non_negative
 
+from hypertorch.train.logger import ExperimentSharedLogger
 
-class MarkdownTableLogger(Logger):
+
+class MarkdownTableLogger(ExperimentSharedLogger):
     """
     A Lightning Logger that accumulates metrics and writes a markdown comparison table.
 
@@ -106,6 +107,18 @@ class MarkdownTableLogger(Logger):
             experiment_name: The experiment name whose data should be cleared.
         """
         self.__shared_stores.pop(experiment_name, None)
+
+    def destroy(self) -> None:
+        """
+        Destroy the internal shared state of the logger.
+
+        Caution: This method should be used with care, as it will clear all shared
+            state across experiments and processes. This means that any metrics or data logged
+            by other experiments will be lost as well. Use this method only when you are certain
+            that you want to clear all shared state, and not just the state for
+            a specific experiment. In that case, use the `clear` methods instead.
+        """
+        self.__shared_stores.clear()
 
     def log_hyperparams(self, params: Any) -> None:
         """

--- a/hypertorch/train/markdown_logger.py
+++ b/hypertorch/train/markdown_logger.py
@@ -3,6 +3,7 @@ import copy
 from pathlib import Path
 from typing import Any, ClassVar
 from collections.abc import Mapping
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 from hypertorch.utils import MARKDOWN_CHARACTER_ESCAPE_TABLE, escape, validate_is_non_negative
 
 from hypertorch.train.logger import ExperimentSharedLogger
@@ -16,6 +17,10 @@ class MarkdownTableLogger(ExperimentSharedLogger):
     Every time ``finalize()`` is called (after ``fit()`` or ``test()`` for each model), the current
     state of all accumulated metrics is written to a markdown file. The last model to
     finalize produces the most complete table.
+
+    In distributed runs, only global rank zero accumulates metrics and writes tables.
+    Metrics must therefore be synchronized before they reach the logger, for example by
+    passing ``sync_dist=True`` to Lightning's metric logging methods.
 
     This means the file is progressively updated as models finish training/testing,
     so partial results are available while running.
@@ -113,10 +118,10 @@ class MarkdownTableLogger(ExperimentSharedLogger):
         Destroy the internal shared state of the logger.
 
         Caution: This method should be used with care, as it will clear all shared
-            state across experiments and processes. This means that any metrics or data logged
-            by other experiments will be lost as well. Use this method only when you are certain
-            that you want to clear all shared state, and not just the state for
-            a specific experiment. In that case, use the `clear` methods instead.
+            state across experiments in the current process. This means that any metrics
+            or data logged by other experiments will be lost as well. Use this method only
+            when you are certain that you want to clear all shared state, and not just the
+            state for a specific experiment. In that case, use the `clear` methods instead.
         """
         self.__shared_stores.clear()
 
@@ -129,6 +134,7 @@ class MarkdownTableLogger(ExperimentSharedLogger):
         """
         pass
 
+    @rank_zero_only
     def log_metrics(self, metrics: dict[str, float], step: int | None = None) -> None:
         """
         Accumulate metrics for this model. Called by Lightning on every log step.
@@ -145,6 +151,7 @@ class MarkdownTableLogger(ExperimentSharedLogger):
             store[self.__model_name] = {}
         store[self.__model_name].update(metrics)
 
+    @rank_zero_only
     def finalize(self, status: str) -> None:
         """
         Write the markdown comparison table with all accumulated metrics so far.

--- a/hypertorch/train/trainer.py
+++ b/hypertorch/train/trainer.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import os
 import shutil
 import subprocess
 import warnings
 import lightning as L
 import torch
 
+from itertools import count
 from pathlib import Path
 from typing import Any, cast
 from collections.abc import Iterable, Mapping
@@ -25,9 +27,29 @@ from hypertorch.train.markdown_logger import MarkdownTableLogger
 from hypertorch.train.latex_logger import LaTexTableLogger
 
 
+AUTO_EXPERIMENT_DIR_ENV_PREFIX = "HYPERTORCH_AUTO_EXPERIMENT_DIR"
+AUTO_EXPERIMENT_INDEX = count()
+
+
 class MultiModelTrainer:
     """
     A trainer class to handle training multiple models with individual trainers.
+
+    When ``experiment_name`` is ``None``, an auto-selected directory is exported through
+    ``HYPERTORCH_AUTO_EXPERIMENT_DIR_<index>``. This is for distributed settings, as
+    Lightning child processes launched after this trainer is constructed inherit
+    that value and reuse the parent's directory.
+    The zero-based index identifies the construction order of auto-named
+    ``MultiModelTrainer`` instances, so relaunched processes must construct them in the
+    same order.
+
+    External launchers such as ``torchrun`` start sibling processes before this code runs,
+    so environment changes made by one rank are not propagated to the others. With such
+    launchers, pass the same explicit ``experiment_name`` to every rank or preconfigure the
+    indexed environment variables before launch. For example,
+    ``HYPERTORCH_AUTO_EXPERIMENT_DIR_0="..." HYPERTORCH_AUTO_EXPERIMENT_DIR_1="..." ...``
+    The resolved directory must be accessible from every rank;
+    multi-machine jobs therefore require shared storage.
 
     Attributes:
         model_configs: Model configurations managed by the trainer.
@@ -88,7 +110,10 @@ class MultiModelTrainer:
                 associated trainer (if any).
             experiment_name: Name for this experiment run's log directory. When ``None`` (default),
                 auto-increments as ``experiment_0``, ``experiment_1``, etc. under
-                the log root directory. Only used when ``logger`` is not provided.
+                the log root directory. Lightning-launched child processes on the same machine
+                inherit the selected directory. For external launchers such as ``torchrun``,
+                provide the same explicit name on every rank or set
+                ``HYPERTORCH_AUTO_EXPERIMENT_DIR_<index>`` before launch.
             accelerator: Supports passing different accelerator types
                 ("cpu", "gpu", "tpu", "hpu", "mps", "auto") as well as custom accelerator instances.
             devices: The devices to use. Can be set to a positive number (int or str), a
@@ -777,6 +802,11 @@ class MultiModelTrainer:
         """
         Resolve the log directory for this trainer instance.
 
+        Auto-named directories are exported through an environment variable indexed by
+        trainer construction order. This allows Lightning-relaunched child processes to
+        reuse the parent's directory, provided they reconstruct auto-named trainers in the
+        same order. It does not coordinate sibling processes started by external launchers.
+
         Args:
             default_root_dir: Optional root directory for logs.
             experiment_name: Optional explicit experiment directory name.
@@ -788,7 +818,24 @@ class MultiModelTrainer:
             Path(self.DEFAULT_BASE_LOG_DIR) if default_root_dir is None else Path(default_root_dir)
         )
         if experiment_name is None:
-            return self.__reserve_next_experiment_dir(base_dir)
+            experiment_index = next(AUTO_EXPERIMENT_INDEX)
+            environment_variable = f"{AUTO_EXPERIMENT_DIR_ENV_PREFIX}_{experiment_index}"
+            inherited_log_dir = os.environ.get(environment_variable)
+            if inherited_log_dir is not None:
+                # If a parent process has already reserved an auto-named directory, reuse it.
+                return Path(inherited_log_dir)
+
+            # Create the next experiment directory and reserve it for this trainer instance,
+            # but only if it is not already reserved by a parent process. This ensures that
+            # Lightning-relaunched child processes can reuse the same directory when they
+            # reconstruct auto-named trainers in the same order.
+            log_dir = self.__reserve_next_experiment_dir(base_dir).resolve()
+
+            # Export the reserved directory through an environment variable for child processes
+            # to inherit, in case this is a distributed training setup.
+            os.environ[environment_variable] = str(log_dir)
+            return log_dir
+
         return base_dir / experiment_name
 
     def __reserve_next_experiment_dir(self, base_dir: Path) -> Path:

--- a/hypertorch/train/trainer.py
+++ b/hypertorch/train/trainer.py
@@ -17,6 +17,7 @@ from lightning.pytorch.loggers import CSVLogger, Logger
 from lightning.pytorch.profilers import Profiler
 from lightning.pytorch.strategies import Strategy
 from hypertorch.data import DataLoader, DataModule
+from hypertorch.train.logger import ExperimentSharedLogger
 from hypertorch.types import CkptStrategy, ModelConfig, TestResult
 from hypertorch.utils import validate_is_non_empty, validate_is_non_negative
 
@@ -210,6 +211,7 @@ class MultiModelTrainer:
         validate_is_non_empty("model_configs", self.model_configs)
 
         self.log_dir: Path = self.__logdir(default_root_dir, experiment_name)
+        self.__experiment_key = str(self.log_dir)
 
         self.auto_start_tensorboard: bool = auto_start_tensorboard
         self.tensorboard_port: int = tensorboard_port
@@ -536,6 +538,28 @@ class MultiModelTrainer:
         if self.__tensorboard_process is not None:
             self.__tensorboard_process.terminate()
             self.__tensorboard_process = None
+        self.__clear_loggers()
+
+    def __clear_loggers(self) -> None:
+        """
+        Clear the internal state of all loggers.
+
+        This is called by Lightning when a new experiment starts, so that metrics from
+        previous experiments do not carry over.
+        """
+        if getattr(self, "_MultiModelTrainer__experiment_key", None) is None:
+            return
+
+        for config in self.model_configs:
+            if config.trainer is not None and config.trainer.loggers is not None:
+                for logger in config.trainer.loggers:
+                    if isinstance(logger, ExperimentSharedLogger):
+                        logger.clear(self.__experiment_key)
+
+            if config.test_trainer is not None and config.test_trainer.loggers is not None:
+                for logger in config.test_trainer.loggers:
+                    if isinstance(logger, ExperimentSharedLogger):
+                        logger.clear(self.__experiment_key)
 
     def wait(self) -> None:
         """
@@ -726,15 +750,6 @@ class MultiModelTrainer:
         Returns:
             experiment_name: Next experiment directory name.
         """
-        if not save_dir.exists():
-            # Example: EXPERIMENT_NAME_PREFIX = "experiment",
-            #          EXPERIMENT_SEPARATOR = "_",
-            #          FIRST_EXPERIMENT_NUMBER = 0
-            #          -> next_experiment_name = "experiment_0"
-            return Path(
-                f"{self.EXPERIMENT_NAME_PREFIX}{self.EXPERIMENT_SEPARATOR}{self.FIRST_EXPERIMENT_NUMBER}"
-            )
-
         existing_experiment_names: list[str] = [
             dir.name
             for dir in save_dir.iterdir()
@@ -772,12 +787,34 @@ class MultiModelTrainer:
         base_dir = (
             Path(self.DEFAULT_BASE_LOG_DIR) if default_root_dir is None else Path(default_root_dir)
         )
-        next_experiment_name = (
-            self.__next_experiment_name(base_dir)
-            if experiment_name is None
-            else Path(experiment_name)
-        )
-        return base_dir / next_experiment_name
+        if experiment_name is None:
+            return self.__reserve_next_experiment_dir(base_dir)
+        return base_dir / experiment_name
+
+    def __reserve_next_experiment_dir(self, base_dir: Path) -> Path:
+        """
+        Atomically select and reserve the next experiment directory.
+
+        Args:
+            base_dir: Base directory containing experiment directories.
+
+        Returns:
+            experiment_dir: Reserved experiment directory.
+        """
+        base_dir.mkdir(parents=True, exist_ok=True)
+
+        while True:  # Until we successfully reserve a directory, keep trying
+            new_experiment_name = self.__next_experiment_name(base_dir)
+            new_experiment_dir = base_dir / new_experiment_name
+
+            try:
+                new_experiment_dir.mkdir(exist_ok=False)
+            except FileExistsError:
+                # Another trainer reserved this name after we calculated it,
+                # so we need to try again to find the next available name.
+                continue
+
+            return new_experiment_dir
 
     def __setup_logger(
         self,
@@ -797,8 +834,6 @@ class MultiModelTrainer:
         if logger is not None:
             return logger
 
-        experiment_name = str(self.__next_experiment_name(self.log_dir))
-
         loggers: list[Logger] = [
             CSVLogger(
                 save_dir=self.log_dir,
@@ -808,12 +843,12 @@ class MultiModelTrainer:
             MarkdownTableLogger(
                 save_dir=self.log_dir,
                 model_name=model_config.full_model_name(),
-                experiment_name=experiment_name,
+                experiment_name=self.__experiment_key,
             ),
             LaTexTableLogger(
                 save_dir=self.log_dir,
                 model_name=model_config.full_model_name(),
-                experiment_name=experiment_name,
+                experiment_name=self.__experiment_key,
                 options={
                     "table_caption": "Results for Experiments",
                     "sort_by": ["des", "asc"],


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

- Correct experiment name usage in loggers/trainer, so that they use the same consistently.
- Force no duplicate experiment directory when two trainers are initialized at the same time.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you lint your code locally before submission? (use `make format`)
- [x] Have you type checked your code locally before submission? (use `make typecheck`)
