### PR TITLE
feat: add test-specific DataLoader configuration

### DIFF
--- a/docs/user-guide/training.md
+++ b/docs/user-guide/training.md
@@ -88,8 +88,9 @@ with MultiModelTrainer(
     trainer.test_all(dataloader=test_loader)
 ```
 
-When the train, validation, and test loaders use the same parameters, create all three
-through a Lightning-compatible data module:
+When the train, validation, and test loaders share parameters, create all three through
+a Lightning-compatible data module. Use `test_loader_kwargs` for settings that should
+apply only to the test loader:
 
 ```python
 data_module = DataLoader.from_datasets(
@@ -100,6 +101,10 @@ data_module = DataLoader.from_datasets(
     shuffle=False,
     num_workers=4,
     persistent_workers=True,
+    test_loader_kwargs={
+        "batch_size": 1,
+        "sample_full_hypergraph": True,
+    },
 )
 
 with MultiModelTrainer(
@@ -115,8 +120,9 @@ with MultiModelTrainer(
     trainer.test_all(dataloader=data_module.test_dataloader())
 ```
 
-Datasets can be omitted when a split is not needed. Its corresponding data module hook
-then returns `None`.
+Values in `test_loader_kwargs` override shared values for the test loader without
+affecting the train or validation loaders. Datasets can be omitted when a split is not
+needed. Its corresponding data module hook then returns `None`.
 
 For hyperlink prediction, transductive splits keep the full hypergraph as context in each split and mark the supervised hyperedges with `hdata.target_hyperedge_mask`.
 

--- a/hypertorch/data/loader.py
+++ b/hypertorch/data/loader.py
@@ -109,13 +109,15 @@ class DataLoader(TorchDataLoader):
         train_dataset: Dataset | None = None,
         val_dataset: Dataset | None = None,
         test_dataset: Dataset | None = None,
+        test_loader_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> DataModule:
         """
         Create a Lightning data module from datasets that share data loader parameters.
 
         Each provided dataset is wrapped in a separate `DataLoader`. The resulting data
-        module can be passed directly to Lightning or to `MultiModelTrainer`.
+        module can be passed directly to Lightning or to `MultiModelTrainer`. Parameters
+        in `test_loader_kwargs` override shared parameters for the test data loader only.
 
         Examples:
             ```python
@@ -127,6 +129,7 @@ class DataLoader(TorchDataLoader):
                 shuffle=False,
                 num_workers=4,
                 persistent_workers=True,
+                test_loader_kwargs={"batch_size": 256, "shuffle": False},
             )
             ```
 
@@ -134,15 +137,25 @@ class DataLoader(TorchDataLoader):
             train_dataset: Optional dataset used by the data module's training data loader.
             val_dataset: Optional dataset used by the data module's validation data loader.
             test_dataset: Optional dataset used by the data module's test data loader.
+            test_loader_kwargs: Optional parameters that override shared `kwargs` for the
+                test data loader.
             kwargs: Parameters passed to every created `DataLoader`.
 
         Returns:
             data_module: A Lightning data module containing the created data loaders.
         """
+        resolved_test_loader_kwargs = {
+            **kwargs,
+            **(test_loader_kwargs or {}),
+        }
         return DataLoaderDataModule(
             train_dataloader=cls(train_dataset, **kwargs) if train_dataset is not None else None,
             val_dataloader=cls(val_dataset, **kwargs) if val_dataset is not None else None,
-            test_dataloader=cls(test_dataset, **kwargs) if test_dataset is not None else None,
+            test_dataloader=(
+                cls(test_dataset, **resolved_test_loader_kwargs)
+                if test_dataset is not None
+                else None
+            ),
         )
 
     def collate(self, batch: list[HData]) -> HData:

--- a/hypertorch/tests/data/loader_test.py
+++ b/hypertorch/tests/data/loader_test.py
@@ -179,6 +179,70 @@ def test_from_datasets_creates_loaders_with_shared_params(mock_dataset_single_sa
     assert len({id(loader) for loader in loaders}) == 3
 
 
+def test_from_datasets_applies_test_loader_overrides_without_mutating_params(
+    mock_dataset_single_sample,
+):
+    shared_params = {
+        "batch_size": 2,
+        "drop_last": False,
+        "in_order": True,
+    }
+    test_loader_params = {
+        "batch_size": 1,
+        "drop_last": True,
+        "in_order": False,
+    }
+
+    data_module = DataLoader.from_datasets(
+        train_dataset=mock_dataset_single_sample,
+        val_dataset=mock_dataset_single_sample,
+        test_dataset=mock_dataset_single_sample,
+        test_loader_kwargs=test_loader_params,
+        **shared_params,
+    )
+
+    train_loader = cast(DataLoader, data_module.train_dataloader())
+    val_loader = cast(DataLoader, data_module.val_dataloader())
+    test_loader = cast(DataLoader, data_module.test_dataloader())
+
+    assert train_loader.batch_size == 2
+    assert train_loader.drop_last is False
+    assert train_loader.in_order is True
+    assert val_loader.batch_size == 2
+    assert val_loader.drop_last is False
+    assert val_loader.in_order is True
+    assert test_loader.batch_size == 1
+    assert test_loader.drop_last is True
+    assert test_loader.in_order is False
+    assert shared_params == {
+        "batch_size": 2,
+        "drop_last": False,
+        "in_order": True,
+    }
+    assert test_loader_params == {
+        "batch_size": 1,
+        "drop_last": True,
+        "in_order": False,
+    }
+
+
+def test_from_datasets_ignores_test_loader_params_without_test_dataset(
+    mock_dataset_single_sample,
+):
+    test_loader_params = {"batch_size": 2}
+
+    data_module = DataLoader.from_datasets(
+        train_dataset=mock_dataset_single_sample,
+        test_loader_kwargs=test_loader_params,
+        batch_size=1,
+    )
+
+    train_loader = cast(DataLoader, data_module.train_dataloader())
+    assert train_loader.batch_size == 1
+    assert data_module.test_dataloader() is None
+    assert test_loader_params == {"batch_size": 2}
+
+
 def test_from_datasets_returns_none_for_omitted_datasets():
     data_module = DataLoader.from_datasets()
 


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

### Description

`DataLoader.from_datasets` currently applies the same loader arguments to the training, validation, and test splits, so callers must construct the test loader separately when it needs different settings.

This change:

- adds an optional `test_loader_kwargs` mapping;
- merges test-specific values over shared loader arguments for the test loader only;
- leaves the training and validation loader configuration unchanged;
- avoids mutating either parameter mapping;
- preserves existing behavior when no overrides or test dataset are supplied; and
- documents the option in the method docstring and training guide.

Focused regression tests cover override precedence, mapping immutability, an omitted test dataset, and the existing shared-configuration behavior.

### Checklist

- [ ] Does your submission pass all tests? (`make test` was not run.)
- [x] Have you written tests to cover all your changes?
- [x] Have you lint your code locally before submission? (The changed Python files pass Ruff formatting and lint checks.)
- [ ] Have you type checked your code locally before submission? (A full dependency-backed type check was not run.)

### Test evidence

- `python -m pytest -q hypertorch/tests/data/loader_test.py -k from_datasets` on Python 3.12: 5 passed, 30 deselected.
- `ruff format --check` on the changed Python files: passed.
- `ruff check` on the changed Python files: passed.
- `python scripts/validate_docstrings.py`: passed.
- `git diff --check`: passed.

### Risks and limitations

The full unit suite, dependency-backed type check, and documentation build were not run locally and remain for CI. The change is limited to test-loader overrides, focused unit coverage, and the corresponding public documentation.

Closes #381