### PR TITLE
chore: fix ref to weekly test script in actions

### DIFF
--- a/.github/workflows/weekly_released_version_test.yaml
+++ b/.github/workflows/weekly_released_version_test.yaml
@@ -26,7 +26,8 @@ jobs:
         run: |
           TAG_TO_CHECK=$(git tag --sort=-creatordate | head -n 1) # latest tag including beta
           COMMIT_TO_CHECK=$(git rev-list -n 1 "$TAG_TO_CHECK")
-          WEEKLY_SCRIPT_URL="https://raw.githubusercontent.com/hypernetwork-research-group/hypertorch/${COMMIT_TO_CHECK}/scripts/weekly_run.sh"
+          SCRIPT_COMMIT=$(git rev-parse HEAD)
+          WEEKLY_SCRIPT_URL="https://raw.githubusercontent.com/hypernetwork-research-group/hypertorch/${SCRIPT_COMMIT}/scripts/weekly_run.sh"
           echo "tag=$TAG_TO_CHECK" >> "$GITHUB_OUTPUT"
           echo "weekly_script_url=$WEEKLY_SCRIPT_URL" >> "$GITHUB_OUTPUT"
           {
@@ -35,7 +36,8 @@ jobs:
             echo "| Variable | Value |"
             echo "| --- | --- |"
             echo "| Tag | \`$TAG_TO_CHECK\` |"
-            echo "| Commit | \`$COMMIT_TO_CHECK\` |"
+            echo "| Release commit | \`$COMMIT_TO_CHECK\` |"
+            echo "| Weekly script commit | \`$SCRIPT_COMMIT\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   test-ubuntu-x86:


### PR DESCRIPTION
### All submissions

- [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document?
- [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same changes?
- [x] Have you made sure you have rebased your branch to the latest commit on the target branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Tests for the released version were failing because they used the CI script included in the GitHub release, which was affected by timeouts on macOS runners. This PR changes the workflow to always use the latest version of the CI script, allowing us to update it independently without making the released package depend on a specific script version.

### Checklist

- [x] Does your submission pass all tests? (use `make test`)
- [x] Have you written tests to cover all your changes? If not, provide a reason.
- [x] Have you linted your code locally before submission? (use `make format`)
- [x] Have you type-checked your code locally before submission? (use `make typecheck`)
